### PR TITLE
make build check more strict

### DIFF
--- a/docs/android/changelog.md
+++ b/docs/android/changelog.md
@@ -142,7 +142,7 @@ API Desugaring is now a requirement for apps that support Android 5 and 6. This 
 ## 6.4.0
 *March 6, 2024*
 - Traces improvements
-    - Support configuration of OpenTelemetry Exporters to export [Traces](/android/features/traces/#export-your-telemetry) data as OpenTelemetry Spans (beta).
+    - Support configuration of OpenTelemetry Exporters to export [Traces](/android/features/traces/#export-to-opentelemetry-collectors) data as OpenTelemetry Spans (beta).
     - Change timestamps parameters of the APIs to use milliseconds to better align with Android developer expectations. 
         - Note: timestamps that are in nanoseconds will be detected and converted for now so existing instrumentation will still work, but this will be removed in an upcoming release.
     - Increase per-session limit of spans to 500 in total.

--- a/docs/ios/5x/features/configuration-file.md
+++ b/docs/ios/5x/features/configuration-file.md
@@ -94,7 +94,7 @@ Sets a default limit for how many instances of any given domain to capture in a 
 
 ##### NETWORK:DOMAINS *dictionary[string, int], optional*
 
-This dictionary maps domains to capture limits. It should consist of string keys for domains we might capture. The value for each domain entry should be the corresponding capture limit. Any domain not in this list will use the [**DEFAULT_CAPTURE_LIMIT**](#networkdefault_capture_limit-int-optional).
+This dictionary maps domains to capture limits. It should consist of string keys for domains we might capture. The value for each domain entry should be the corresponding capture limit. Any domain not in this list will use the [**DEFAULT_CAPTURE_LIMIT**](#network-int-optional).
 
 ##### NETWORK:CAPTURE_PUBLIC_KEY *string, optional*
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -24,7 +24,9 @@ const config: Config = {
   projectName: "embrace-docs", // Usually your repo name.
 
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
+  onBrokenMarkdownLinks: "throw",
+  onDuplicateRoutes: "throw",
+  onBrokenAnchors: "throw",
 
   i18n: {
     defaultLocale: "en",


### PR DESCRIPTION
Added some extra checks for broken routes

```
  onBrokenMarkdownLinks: "throw",
  onDuplicateRoutes: "throw",
  onBrokenAnchors: "throw",
```

Now the build will fail with something like
![image](https://github.com/user-attachments/assets/f623b653-4576-47d3-9bfa-0f9a3c42b6e1)

when it finds a broken link.

Note: I fixed the 2 broken links to start with a clean build when enforcing these new rules