### PR TITLE
EMBR-5606 adjust grouping wording

### DIFF
--- a/docs/features/error-logs-tracking.md
+++ b/docs/features/error-logs-tracking.md
@@ -8,7 +8,7 @@ sidebar_position: 2
 
 The logs section gives you access to all logs emitted by your application. Embrace provides two ways to explore your logs
 
-- **Aggregated logs**: View logs grouped by wildcarding rules. Typically you would use this visualization for monitoring app performance, identifying trends, and understanding overall user behavior.
+- **Aggregated logs**: View logs grouped by grouping rules. Typically you would use this visualization for monitoring app performance, identifying trends, and understanding overall user behavior.
 - **Raw Logs**: View every single log. Similar to other logging tools, this is a raw list of every log in real time.
 
 ## Filtering options
@@ -37,7 +37,7 @@ For each log group, this page displays:
 - **Devices**: Total number of affected devices in the given time period.
 - **Users**: Percentage of users affected by the log in the given time period.
 - **Versions**: Displays all versions where this log was seen (ignoring filters).
-- **Message**: Wildcarded Log message.
+- **Message**: Grouped Log message.
 
 ### Actions
 

--- a/docs/product/index.md
+++ b/docs/product/index.md
@@ -13,4 +13,4 @@ sidebar_position: 0
 * [User Permissions on Organizations and Projects](/product/permissions/)
 * [Custom Dashboards](/product/custom-dashboards/)
 * [Network Spans Forwarding](/product/network-spans-forwarding/)
-* [Network Rollup Rules](/product/network-rollup-rules/)
+* [Network Grouping Rules](/product/network-grouping-rules/)

--- a/docs/product/network-grouping-rules.md
+++ b/docs/product/network-grouping-rules.md
@@ -1,20 +1,20 @@
 ---
-title: Custom Network Rollup Rules 
+title: Custom Network Grouping Rules 
 sidebar_position: 1
 ---
 
-# Custom Network Rollup Rules
+# Custom Network Grouping Rules
 
 Embrace provides automatic collapsing of network paths to group similar paths together for analytics purposes.
 We automatically collapse certain path elements if they match a common pattern, and we also group endpoints
 that have a similar prefix. This heuristic can be good enough for most cases, but sometimes it is necessary
 to override the behavior.
 
-On the network settings page you can specify a list of desired groupings (or network rollup rules) that you want to
-apply to your endpoints. When we process a network request, we apply all the network rollup rules in sequence, where
+On the network settings page you can specify a list of desired groupings (or network grouping rules) that you want to
+apply to your endpoints. When we process a network request, we apply all the network grouping rules in sequence, where
 the first|last match wins.
 
-<img src={require('@site/static/images/network-rollup-rules-example.png').default} alt="Screenshot of settings page with network rollup rules" />
+<img src={require('@site/static/images/network-rollup-rules-example.png').default} alt="Screenshot of settings page with network grouping rules" />
 
 Custom rules are applied on the backend on a going forward basis.
 


### PR DESCRIPTION
adjust grouping wording, moving from "rollup" or "widlcarding" to just "grouping" for logs and network products