### PR TITLE
Added a redirect from a very old DPA link.

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -67,6 +67,10 @@ const config: Config = {
       {
         redirects: [
           {
+            to: "/dpa/",
+            from: "/gdpr-data-processing-addendum-dpa/",
+          },
+          {
             to: "/ios/open-source/upgrade-guide/#moments-have-been-replaced-by-traces",
             from: "/ios/open-source/moments-to-tracing/",
           },


### PR DESCRIPTION
I found a link to https://docs.embrace.io/docs/gdpr-data-processing-addendum-dpa in some old PDF documents, so this redirect should make that link work again.

## Checklist before you pull:

[] Please ensure that there is no customer-identifying information in text or images.
[] Please ensure there is no consumer PII in text or images.
[] If you renamed any pages then perhaps you likely want to add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a pair of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`
