### PR TITLE
Update configuration-file.md

### DIFF
--- a/docs/android/features/configuration-file.md
+++ b/docs/android/features/configuration-file.md
@@ -198,7 +198,7 @@ The SDK collects the disk usage for the app. Defaults to `true`.
 
 #### capture_enabled *bool*
 
-Enables background activity capture. Defaults to `false`.
+This is a failsafe. If the remote config is not set, this value will be used. Enable and Disable background activity capture. Defaults to `false`.
 
 #### base_urls - config *string*
 

--- a/docs/android/features/configuration-file.md
+++ b/docs/android/features/configuration-file.md
@@ -198,7 +198,7 @@ The SDK collects the disk usage for the app. Defaults to `true`.
 
 #### capture_enabled *bool*
 
-This is a failsafe. If the remote config is not set, this value will be used. Enable and Disable background activity capture. Defaults to `false`.
+This value is a failsafe to enable or disable background activity capture. If the remote configuration is not set by Embrace's backend, this value will be determine whether or not to enable background capture. Defaults to `false`.
 
 #### base_urls - config *string*
 


### PR DESCRIPTION
Background Activity flag is managed by the remote config. But if the value is not set, or can't be read, the local value will be used. 

Currently, the default remote value is "enabled". So, reading this doc can cause confusion. 
> Enables background activity capture. Defaults to false.

changed to 

> This is a failsafe. If the remote config is not set, this value will be used. Enable and Disable background activity capture. Defaults to `false`.

