### PR TITLE
Updates to where to find Owner Rules in App Settings

### DIFF
--- a/docs/product/tagging.md
+++ b/docs/product/tagging.md
@@ -16,11 +16,16 @@ On any Crash, you can directly create a rule in the stack frame.  Click on the e
 
 <img src={require('@site/static/images/tagging-ui-1.png').default} alt="edit-in-stack" width="500px"/>
 
-<img src={require('@site/static/images/tagging-ui-2.png').default} alt="rule-modal" width="500px"/>
-
+<img src={require('@site/static/images/tagging-ui-3.png').default} alt="rules-in-settings" width="500px"/>
 
 You can also see, create, and modify rules in the Settings view.
-<img src={require('@site/static/images/tagging-ui-3.png').default} alt="rules-in-settings" width="500px"/>
+1. Click on the Settings icon in the lower right hand corner of the dashboard.
+2. Under the "Projects and Apps" section, select the app you want to create
+   rules for.
+3. Expand the desired app and navigate to the "Owner Rules" section.
+4. Modify or create new rules as needed.
+
+<img src={require('@site/static/images/tagging-ui-2.png').default} alt="rule-modal" width="500px"/>
 
 ### With a CODEOWNERS File
 POST your file to `https://dsym-store.emb-api.com/v2/store/tagging/codeowner`.  Include your `app`, 


### PR DESCRIPTION
## Checklist before you pull:

- [x] Please ensure that there is no customer-identifying information in text or images.
- [x] Please ensure there is no consumer PII in text or images.
- [x] If you renamed any pages then perhaps you likely want to add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a pair of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`
---
Updated Crash Tagging page with better clarification on where to find Owner Rules in App Settings. Also rearranged images to be properly aligned with descriptions.
