### PR TITLE
Update docs style guide url

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Checklist before you pull:
 
-- [ ] Double-check that any changes fit the [Embrace Docs Style Guide](https://www.notion.so/embraceio/Embrace-Public-Docs-Style-Guide-19f7e3c99852804abd7deacc2b14cc14).
+- [ ] Double-check that any changes fit the [Embrace Docs Style Guide](https://embraceio.notion.site/Embrace-Public-Docs-Style-Guide-19f7e3c99852804abd7deacc2b14cc14).
 - [ ] Please ensure that there is no customer-identifying information in text or images.
 - [ ] Please ensure there is no consumer PII in text or images.
 - [ ] If you renamed any pages then perhaps you likely want to add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a pair of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 
 ## Updating These Docs
 
-You can make edits to these docs from within GitHub UI or by forking/cloning the repo to make edits locally. Ensure that any edits conform to the [Embrace Docs Style Guide](https://www.notion.so/embraceio/Embrace-Public-Docs-Style-Guide-19f7e3c99852804abd7deacc2b14cc14).
+You can make edits to these docs from within GitHub UI or by forking/cloning the repo to make edits locally. Ensure that any edits conform to the [Embrace Docs Style Guide](https://embraceio.notion.site/Embrace-Public-Docs-Style-Guide-19f7e3c99852804abd7deacc2b14cc14).
 
 ### Recommendations
 


### PR DESCRIPTION
## Checklist before you pull:

- [ ] Double-check that any changes fit the [Embrace Docs Style Guide](https://www.notion.so/embraceio/Embrace-Public-Docs-Style-Guide-19f7e3c99852804abd7deacc2b14cc14).
- [ ] Please ensure that there is no customer-identifying information in text or images.
- [ ] Please ensure there is no consumer PII in text or images.
- [ ] If you renamed any pages then perhaps you likely want to add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a pair of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`
