### PR TITLE
fix link to LogSeverity in apple repo

### DIFF
--- a/docs/ios/open-source/getting-started/logs.md
+++ b/docs/ios/open-source/getting-started/logs.md
@@ -40,7 +40,7 @@ Embrace.client?.log(
 Let's examine the method call from above to understand the arguments involved:
 
 1. **message**: The first argument is a string and represents the message itself.
-1. **severity**: This is the [LogSeverity](https://github.com/embrace-io/embrace-apple-sdk/blob/main/Sources/EmbraceCommonInternal/Enums/LogSeverity.swift) of the event. Typically we use this mechanism for errors and warnings and occasionally for tracing purposes, but that is better left to [breadcrumbs](/docs/ios/open-source/getting-started/breadcrumbs.md).
+1. **severity**: This is the [LogSeverity](https://github.com/embrace-io/embrace-apple-sdk/blob/main/Sources/EmbraceCommonInternal/Models/LogSeverity.swift) of the event. Typically we use this mechanism for errors and warnings and occasionally for tracing purposes, but that is better left to [breadcrumbs](/docs/ios/open-source/getting-started/breadcrumbs.md).
 1. **timestamp**: This is the time that this log message should show in the timeline. If the log points to an error or warning happening prior to the current time, the timestamp for the occurrence can be added here.
 1. **attributes**: This is a dictionary of key-value pairs. When logging an event, break out any details into this dictionary and you will be able to categorize and filter on those values.
 


### PR DESCRIPTION
## Checklist before you pull:

- [ ] Double-check that any changes fit the [Embrace Docs Style Guide](https://embraceio.notion.site/Embrace-Public-Docs-Style-Guide-19f7e3c99852804abd7deacc2b14cc14).
- [ ] Please ensure that there is no customer-identifying information in text or images.
- [ ] Please ensure there is no consumer PII in text or images.
- [ ] If you renamed any pages then perhaps you likely want to add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a pair of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`
