### PR TITLE
[DNM] Add reference page for embrace gradle plugin

### DIFF
--- a/docs/android/faq.md
+++ b/docs/android/faq.md
@@ -95,7 +95,7 @@ Alternatively you can set your `minSdk` to 24 to avoid the problem.
 
 In addition to performing the basic integration instructions, you must specify the Embrace SDK dependency directly in your module's Gradle file
 implementation `'io.embrace:embrace-android-sdk:<version>'`.
-You still need to apply the Swazzler plugin in the app's Gradle file `(apply plugin: 'embrace-swazzler')` and verify that the Swazzler version set in your project Gradle file is the same as the version set for the SDK in the module’s Gradle file
+You still need to apply the Embrace Gradle Plugin in the app's Gradle file `(apply plugin: 'embrace-swazzler')` and verify that the version set in your project Gradle file is the same as the version set for the SDK in the module’s Gradle file
 
 ```groovy
 buildscript {
@@ -113,7 +113,7 @@ buildscript {
 
 ### **Is there a way that I can speed up build times?**
 
-Yes, update to the latest version of the swazzler gradle plugin & ensure your AGP + Gradle version are on the latest stable version.
+Yes, update to the latest version of the Embrace Gradle Plugin & ensure your AGP + Gradle version are on the latest stable version.
 Newer AGP versions provide a more performant API for bytecode instrumentation amongst other improvements that our plugin relies upon.
 
 ### **Does adding the Embrace SDK impact launch performance?**

--- a/docs/android/features/embrace-gradle-plugin.md
+++ b/docs/android/features/embrace-gradle-plugin.md
@@ -16,7 +16,7 @@ The Embrace Gradle Plugin performs several functions:
 
 ## Apply the Embrace Gradle Plugin
 
-To apply the Embrace Gradle Plugin to your app follow the instructions in our [integration steps](/docs/android/integration/integration-steps).
+To apply the Embrace Gradle Plugin to your app follow the instructions in our [integration steps](/android/integration/integration-steps).
 
 ## Configure the Embrace Gradle Plugin
 

--- a/docs/android/features/embrace-gradle-plugin.md
+++ b/docs/android/features/embrace-gradle-plugin.md
@@ -1,0 +1,163 @@
+---
+title: Embrace Gradle Plugin
+description: Get readable stacktraces in production with the Embrace Gradle Plugin and auto-instrument your app
+sidebar_position: 20
+---
+
+# Embrace Gradle Plugin
+
+## Overview
+
+The Embrace Gradle Plugin performs several functions:
+1. It uploads mapping files to the Embrace backend that are required to get readable stacktraces from production apps
+2. It instruments your app's bytecode to insert SDK hooks that capture telemetry out-of-the-box
+3. It adds Embrace dependencies to your project's compile classpath
+4. It injects your specified configuration for the Embrace SDK into the APK/App Bundle
+
+## Apply the Embrace Gradle Plugin
+
+To apply the Embrace Gradle Plugin to your app follow the instructions in our [integration steps](/docs/android/integration/integration-steps).
+
+## Configure the Embrace Gradle Plugin
+
+The Embrace Gradle Plugin should be configured via the `build.gradle` of the module where you applied the plugin. The full DSL is shown here, and explained in more detail below the code snippet:
+
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+
+<Tabs groupId="android-language" queryString="android-language">
+<TabItem value="groovy" label="Groovy">
+
+```groovy
+plugins {
+    id 'io.embrace.swazzler'
+}
+
+embrace {
+    autoAddEmbraceDependencies.set(true)
+    autoAddEmbraceComposeClickDependency.set(false)
+    telemetryEnabled.set(true)
+    failBuildOnUploadErrors.set(true)
+
+    bytecodeInstrumentation {
+        enabled.set(true)
+        okhttpEnabled.set(true)
+        onClickEnabled.set(true)
+        onLongClickEnabled.set(true)
+        webviewOnPageStartedEnabled.set(true)
+        firebasePushNotificationsEnabled.set(true)
+        classIgnorePatterns.set(["com.example.foo.*"])
+    }
+
+    buildVariantFilter {
+        if (it.name.contains("debug")) {
+            it.disablePluginForVariant()
+            it.disableBytecodeInstrumentationForVariant()
+        }
+    }
+}
+```
+
+</TabItem>
+
+<TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+plugins {
+    id("io.embrace.swazzler")
+}
+
+embrace {
+    autoAddEmbraceDependencies.set(true)
+    autoAddEmbraceComposeClickDependency.set(false)
+    telemetryEnabled.set(true)
+    failBuildOnUploadErrors.set(true)
+
+    bytecodeInstrumentation {
+        enabled.set(true)
+        okhttpEnabled.set(true)
+        onClickEnabled.set(true)
+        onLongClickEnabled.set(true)
+        webviewOnPageStartedEnabled.set(true)
+        firebasePushNotificationsEnabled.set(true)
+        classIgnorePatterns.set(listOf("com.example.foo.*"))
+    }
+
+    buildVariantFilter {
+        if (name.contains("debug")) {
+            disablePluginForVariant()
+            disableBytecodeInstrumentationForVariant()
+        }
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+### Gradle DSL reference
+
+#### autoAddEmbraceDependencies
+
+Whether the Embrace Gradle Plugin should automatically add Embrace dependencies to this module's classpath. Defaults to true.
+
+#### autoAddEmbraceComposeClickDependency
+
+Whether the Embrace Gradle Plugin should automatically add the embrace-android-compose dependency to this module's classpath. Defaults to false.
+
+#### telemetryEnabled
+
+Whether the Embrace Gradle Plugin should report telemetry on its own performance. Defaults to true.
+
+#### failBuildOnUploadErrors
+
+Whether the Embrace Gradle Plugin should fail the build if it encounters an error during a HTTP request. Defaults to true.
+
+#### bytecodeInstrumentation.enabled
+
+Global flag that overrides all others & decides whether Embrace should perform any bytecode instrumentation. Defaults to true.
+
+#### bytecodeInstrumentation.okhttpEnabled
+
+Whether Embrace should automatically instrument OkHttp requests. Defaults to true.
+
+#### bytecodeInstrumentation.onClickEnabled
+
+Whether Embrace should automatically instrument android.view.View click events. Defaults to true.
+
+#### bytecodeInstrumentation.onLongClickEnabled
+
+Whether Embrace should automatically instrument android.view.View long click events. Defaults to true.
+
+#### bytecodeInstrumentation.webviewOnPageStartedEnabled
+
+Whether Embrace should automatically instrument onPageStarted() in webviews. Defaults to true.
+
+#### bytecodeInstrumentation.firebasePushNotificationsEnabled
+
+Whether Embrace should automatically instrument push notifications from Firebase. Defaults to false.
+
+#### bytecodeInstrumentation.classIgnorePatterns
+
+A list of string patterns that are used to filter classes during bytecode instrumentation. For example, `'com.example.foo.*'`
+would avoid instrumenting any classes in the `'com.example.foo'` package.
+
+This can be useful if you wish to avoid instrumenting certain parts of your codebase. Defaults to an empty list.
+
+#### buildVariantFilter
+
+Controls how the Embrace Gradle Plugin behaves on a specific build variant. You can use this by checking the variant name and then configuring the build variant as required.
+
+For example, if you wish to disable bytecode instrumentation for any build variant with the 'debug' buildType you could specify the following:
+
+```kotlin
+embrace {
+    buildVariantFilter {
+        if (name.contains("debug")) {
+            disableBytecodeInstrumentationForVariant()
+        }
+    }
+}
+```

--- a/docs/android/features/jetpack-compose.md
+++ b/docs/android/features/jetpack-compose.md
@@ -6,7 +6,7 @@ sidebar_position: 13
 
 # Jetpack Compose
 
-The Embrace SDK injects code into your APK using a process we call “swazzling” to automatically capture taps on composables.
+The Embrace SDK injects code into your APK using bytecode instrumentation to automatically capture taps on composables.
 
 ## Enabling Jetpack Compose instrumentation
 
@@ -18,7 +18,7 @@ Requires Jetpack Compose dependency at build time and run time
 Instrumenting Jetpack Compose click events incurs a small performance penalty on a tap as it requires searching Compose's UI tree. On lower-end devices this may manifest as dropped frames.
 :::
 
-### Set Local config and swazzler block
+### Set Local config and gradle plugin block
 
 To enable onClick instrumentation, You will need to modify your `embrace-config.json` [file](/android/features/configuration-file.md)
 

--- a/docs/android/features/jetpack-compose.md
+++ b/docs/android/features/jetpack-compose.md
@@ -18,7 +18,7 @@ Requires Jetpack Compose dependency at build time and run time
 Instrumenting Jetpack Compose click events incurs a small performance penalty on a tap as it requires searching Compose's UI tree. On lower-end devices this may manifest as dropped frames.
 :::
 
-### Set Local config and gradle plugin block
+### Set Local config and Gradle plugin block
 
 To enable onClick instrumentation, You will need to modify your `embrace-config.json` [file](/android/features/configuration-file.md)
 

--- a/docs/android/features/push-notifications.md
+++ b/docs/android/features/push-notifications.md
@@ -17,8 +17,10 @@ The only requirement is having `embrace.useAsmTransformApi` enabled, but it's en
 If you want to enable the Push Notifications feature, you can set `instrumentFirebaseMessaging` to true in your `app/build.gradle` file.
 
 ```groovy
-swazzler {
-    instrumentFirebaseMessaging = true
+embrace {
+    bytecodeInstrumentation {
+        firebasePushNotificationsEnabled.set(true)
+    }
 }
 
 dependencies {

--- a/docs/android/integration/add-embrace-sdk.md
+++ b/docs/android/integration/add-embrace-sdk.md
@@ -180,7 +180,7 @@ android {
 </TabItem>
 </Tabs>
 
-The Swazzler gradle plugin performs a few key functions:
+The Embrace Gradle Plugin performs a few key functions:
 * Adds the Embrace SDK to your app's dependency list.
 * Injects configuration info the SDK reads at run time.
 * Instruments bytecode to insert SDK hooks that capture telemetry.
@@ -216,7 +216,7 @@ implementation("io.embrace:embrace-android-sdk:{{ embrace_sdk_version platform="
 </TabItem>
 </Tabs>
 
-You still need to apply the Swazzler plugin in the app's Gradle file `(apply plugin: 'embrace-swazzler')` and verify that the Swazzler version set in your project Gradle file is the same as the version set for the SDK in the module’s Gradle file.
+You still need to apply the Embrace Gradle Plugin in the app's Gradle file `(apply plugin: 'embrace-swazzler')` and verify that the version set in your project Gradle file is the same as the version set for the SDK in the module’s Gradle file.
 
 ## Add the config file
 

--- a/docs/android/upgrading.md
+++ b/docs/android/upgrading.md
@@ -1,5 +1,38 @@
 # Upgrade Guide
 
+# Upgrading to the new Embrace Gradle Plugin DSL
+
+The Embrace Gradle Plugin previously had a DSL via the 'swazzler' extension. This has been replaced with a new DSL via the 'embrace'
+extension.
+You can still use the 'swazzler' extension but it is deprecated and will be removed in a future release. It's recommended you use one
+extension or the other, rather than combining their use. Migration instructions are shown
+below:
+
+| Old API                                               | New API                                                                 |
+|-------------------------------------------------------|-------------------------------------------------------------------------|
+| `swazzler.disableDependencyInjection`                 | `embrace.autoAddEmbraceDependencies`                                    |
+| `swazzler.disableComposeDependencyInjection`          | `embrace.autoAddEmbraceComposeClickDependency`                               |
+| `swazzler.instrumentOkHttp`                           | `embrace.bytecodeInstrumentation.okhttpEnabled`                         |
+| `swazzler.instrumentOnClick`                          | `embrace.bytecodeInstrumentation.onClickEnabled`                        |
+| `swazzler.instrumentOnLongClick`                      | `embrace.bytecodeInstrumentation.onLongClickEnabled`                    |
+| `swazzler.instrumentWebview`                          | `embrace.bytecodeInstrumentation.webviewOnPageStartedEnabled`           |
+| `swazzler.instrumentFirebaseMessaging`                | `embrace.bytecodeInstrumentation.firebasePushNotificationsEnabled`      |
+| `swazzler.classSkipList`                              | `embrace.bytecodeInstrumentation.classIgnorePatterns`                   |
+| `swazzler.variantFilter`                              | `embrace.buildVariantFilter`                                            |
+| `SwazzlerExtension.Variant.enabled`                   | `embrace.buildVariantFilter.disableBytecodeInstrumentationForVariant()` |
+| `SwazzlerExtension.Variant.swazzlerOff`               | `embrace.buildVariantFilter.disablePluginForVariant()`                  |
+| `SwazzlerExtension.Variant.setSwazzlingEnabled()`     | `embrace.buildVariantFilter.disableBytecodeInstrumentationForVariant()` |
+| `SwazzlerExtension.Variant.disablePluginForVariant()` | `embrace.buildVariantFilter.disablePluginForVariant()`                  |
+| `embrace.disableCollectBuildData`                     | `embrace.telemetryEnabled`                                              |
+| `swazzler.forceIncrementalOverwrite`                  | Obsolete - no alternative provided.                                     |
+| `swazzler.disableRNBundleRetriever`                   | Obsolete - no alternative provided.                                     |
+| `swazzler.customSymbolsDirectory`                     | Obsolete - no alternative provided.                                     |
+
+The following project properties are now ignored and have no effect. You should remove them from your `gradle.properties` file:
+
+- `embrace.logLevel`
+- `embrace.instrumentationScope`
+
 # Upgrading from 6.x to 7.x
 
 Version 7 of the Embrace Android SDK contains the following breaking changes:

--- a/docs/flutter/features/push-notifications.md
+++ b/docs/flutter/features/push-notifications.md
@@ -13,8 +13,10 @@ If using the [firebase_messaging](https://pub.dev/packages/firebase_messaging) p
 To enable the push notifications capture, you must set `instrumentFirebaseMessaging` to true in the `app/build.gradle` file of your Android project.
 
 ```groovy
-swazzler {
-    instrumentFirebaseMessaging = true
+embrace {
+    bytecodeInstrumentation {
+        firebasePushNotificationsEnabled.set(true)
+    }
 }
 ```
 

--- a/docs/react-native/5x/integration/add-embrace-sdk.md
+++ b/docs/react-native/5x/integration/add-embrace-sdk.md
@@ -78,7 +78,7 @@ so you're good to go!
 
 <TabItem value="android" label="Android">
 
-Update the `build.gradle` file (usually located at `<root>/android/build.gradle`) to include the Embrace Swazzler.
+Update the `build.gradle` file (usually located at `<root>/android/build.gradle`) to include the Embrace Gradle Plugin.
 
 ```groovy
 buildscript {

--- a/docs/react-native/integration/add-embrace-sdk.md
+++ b/docs/react-native/integration/add-embrace-sdk.md
@@ -83,7 +83,7 @@ so you're good to go!
 
 <TabItem value="android" label="Android">
 
-Update the `build.gradle` file (usually located at `<root>/android/build.gradle`) to include the Embrace Swazzler.
+Update the `build.gradle` file (usually located at `<root>/android/build.gradle`) to include the Embrace Gradle Plugin.
 
 ```groovy
 buildscript {

--- a/docs/react-native/upgrading.md
+++ b/docs/react-native/upgrading.md
@@ -205,7 +205,7 @@ Tracing, please refer to [this guide](/react-native/features/traces/) for more i
 
 #### Android
 
-The minimum version of AGP required for the Embrace Swazzler to work as expected is `7.4.2`. If an older version is used for building the React Native Android application it will still build successfully but the SDK won't be able to initialize properly, getting the following error in runtime even when everything is configured as expected:
+The minimum version of AGP required for the Embrace Gradle Plugin to work as expected is `7.4.2`. If an older version is used for building the React Native Android application it will still build successfully but the SDK won't be able to initialize properly, getting the following error in runtime even when everything is configured as expected:
 
 ```bash
 Error occurred while initializing the Embrace SDK. Instrumentation may be disabled.


### PR DESCRIPTION
## Goal

The Embrace Gradle Plugin is largely undocumented and what documentation does exist is scattered through our docs. As part of reviewing our API I felt a reference page for all its functionality would be a good addition to our docs.
