### PR TITLE
EMBR-6016 document react native expo plugin

### DIFF
--- a/docs/react-native/integration/add-embrace-sdk.md
+++ b/docs/react-native/integration/add-embrace-sdk.md
@@ -40,6 +40,36 @@ described in our [Feature Reference](/react-native/features/).
 
 ## Native Setup
 
+### Expo config plugin
+
+If you are using Expo's `prebuild` system to manage your native files you can make use of our config plugin. In your
+`app.json` configure the plugin with your Embrace application IDs and symbol upload API token:
+
+```json
+    "plugins": [
+        ...
+        
+        [
+            "@embrace-io/react-native",
+            {
+                "androidAppId": "__ANDROID_APP_ID__",
+                "iOSAppId": "__IOS_APP_ID__",
+                "apiToken": "__SYMBOL_UPLOAD_API_TOKEN__"
+            }
+        ]
+    ],
+```
+
+:::info
+Refer to [EmbraceProps](https://github.com/embrace-io/embrace-react-native-sdk/tree/main/packages/core/src/plugin//types.ts)
+for the full set properties available to configure the plugin.
+:::
+
+The next time you run `npx expo prebuild` the native Android and iOS files should be updated with the changes required
+by the Embrace SDK. Note that there are other customizations and advanced features of the SDK such as [OTLP Export](/react-native/features/otlp/#initializing-in-the-native-layer)
+which will still require manual editing of native files, at the moment the config plugin only covers this initial SDK
+setup.
+
 ### Setup Script
 
 The JavaScript Embrace SDK ships with a setup script to modify the files in your

--- a/docs/react-native/integration/index.md
+++ b/docs/react-native/integration/index.md
@@ -45,11 +45,8 @@ issue. Apps on versions of React Native older than 0.71 may work with Embrace af
 directly supported. The templates used to generate apps for integration testing along with the exact patch versions of
 React Native we use can be found [here](https://github.com/embrace-io/embrace-react-native-sdk/tree/main/integration-tests/templates).
 
-### Expo
+### Expo support
 
-Apps using Expo should work with Embrace however setup of our SDK does require modification of files within your
-project's native `android/` and `ios/` folders, as such those directories need to be created by running `expo prebuild`
-(or equivalently for older versions the project must be ejected using `expo eject`).
-
-We are developing an Expo Config plugin to better integrate with the framework, you can follow [this issue](https://github.com/embrace-io/embrace-react-native-sdk/issues/308)
-to be notified of progress.
+Apps using Expo are supported by Embrace's React Native SDK. If you are using Expo's `prebuild` system you can make use
+of our [Expo config plugin](/react-native/integration/add-embrace-sdk/#expo-config-plugin) to manage the changes to your
+project's native `android/` and `ios/` folders required by the SDK.


### PR DESCRIPTION
Documentation for the Expo config plugin on React Native: https://github.com/embrace-io/embrace-react-native-sdk/pull/313

Should hold off on merging until an updated version of the React Native SDK is released with that plugin in place