### PR TITLE
Fix iOS 6.x documentation API references and code examples

### DIFF
--- a/docs/ios/6x/core-concepts/user-identification.md
+++ b/docs/ios/6x/core-concepts/user-identification.md
@@ -33,7 +33,10 @@ User Personas allow you to dynamically segment app users according to their beha
 ### Retrieving Current Personas
 
 ```swift
-let personas = Embrace.client?.metadata.currentPersonas
+Embrace.client?.metadata.getCurrentPersonas { personas in
+    print("Current personas: \(personas)")
+    // Use personas here
+}
 ```
 
 ### Adding User Personas
@@ -79,7 +82,7 @@ The value set for `userIdentifier` is not validated by the SDK to follow a speci
 Session Properties provide context about the session or device. They're useful for tracking information that's specific to a particular session:
 
 ```swift
-Embrace.client?.metadata.addProperty(key: "launch type", value: "normal", lifespan: .session)
+try? Embrace.client?.metadata.addProperty(key: "launch_type", value: "normal", lifespan: .session)
 ```
 
 ## Metadata Lifespan

--- a/docs/ios/6x/getting-started/basic-setup.md
+++ b/docs/ios/6x/getting-started/basic-setup.md
@@ -107,7 +107,10 @@ try? Embrace
 
 // Later in your code
 // If setup failed, this will simply not create a span
-let span = Embrace.client?.buildSpan(name: "user-action")
+let span = Embrace.client?.buildSpan(
+    name: "user-action", 
+    type: .performance
+).startSpan()
 // ...
 span?.end()
 ```
@@ -123,13 +126,13 @@ let embrace = try Embrace
     .start()
 
 // Later in your code
-embrace.buildSpan(name: "my-operation").startSpan()
+embrace.buildSpan(name: "my-operation", type: .performance).startSpan()
 ```
 
 2. Use the static client property:
 ```swift
 // After setup has been called
-Embrace.client?.buildSpan(name: "my-operation").startSpan()
+Embrace.client?.buildSpan(name: "my-operation", type: .performance).startSpan()
 ```
 
 ## Checking SDK Status

--- a/docs/ios/index.md
+++ b/docs/ios/index.md
@@ -12,17 +12,19 @@ The Embrace Apple SDK is designed to provide first class observability and diagn
 
 ## Recommended Major Version - Apple 6.x
 
-Our Apple 6.x SDK is recommended for all current and new customers. The 6.x SDK is our [open-source](https://github.com/embrace-io/embrace-apple-sdk) superset of [OpenTelemetry](https://opentelemetry.io) instrumentation, built in Swift for modern language (such as async/await) and mobile observability (spans, logs) features. It has all the latest Embrace features and semantics, and will continue to grow as Embrace helps expand the OTel ecosystem for mobile.
+Our Apple 6.x SDK is the **current recommended version** for all new and existing customers. The 6.x SDK is our [open-source](https://github.com/embrace-io/embrace-apple-sdk) superset of [OpenTelemetry](https://opentelemetry.io) instrumentation, built in Swift for modern language features (such as async/await) and mobile observability (spans, logs). It includes all the latest Embrace features and semantics, and will continue to grow as Embrace helps expand the OTel ecosystem for mobile.
 
-We recommend that customers use our version 6 SDK, as it contains OTel primitives, open-source support, and better use of modern Swift features like async/await. If you are upgrading from our older 5x SDK, a [migration guide](/docs/ios/6x/getting-started/migration-guide.md) is available to implement the new features and interface in the 6.x SDK.
+**Start here for new integrations:** [Getting Started with iOS SDK 6.x](/docs/ios/6x/getting-started/)
 
-## 5.x SDK Documentation
+If you are upgrading from our older 5.x SDK, a [migration guide](/docs/ios/6x/getting-started/migration-guide.md) is available to implement the new features and interface in the 6.x SDK.
 
-Embrace iOS 5.x is the closed-source SDK that has been generally available since the year 2020. It is not available for open-source developers, and is not recommended for new users.
+## 5.x SDK Documentation (Legacy)
 
-Versions 5.x and 6.x are not compatible nor are they interoperable. The 6.x SDK is built on [OpenTelemetry](https://opentelemetry.io), and the features and signals that it provides have different semantics and syntax than previous versions. 6.x is also a rewrite of the SDK in the Swift programming language, so it does not include features that Embrace does not intend to support in the future, like Moments.
+Embrace iOS 5.x is the legacy closed-source SDK that was generally available from 2020-2024. **It is not recommended for new users** and is not available for open-source developers.
 
-This documentation reflects information on the 5.x SDK. It is split into two sections:
+Versions 5.x and 6.x are not compatible nor interoperable. The 6.x SDK is built on [OpenTelemetry](https://opentelemetry.io), and the features and signals that it provides have different semantics and syntax than previous versions. 6.x is also a rewrite of the SDK in the Swift programming language, so it does not include deprecated features like Moments.
+
+Legacy 5.x documentation:
 
 1. [**Integration Guide**](./5x/integration/)
 2. [**Feature Reference**](./5x/features/)


### PR DESCRIPTION
  - Correct API reference with actual SDK methods
  - Fix span creation examples to use buildSpan()
  - Update user identification to use metadata handler
  - Position 6.x as current recommended version
  - Fix code samples to match actual implementation