### PR TITLE
fix grafana collector links

### DIFF
--- a/docs/android/features/traces.md
+++ b/docs/android/features/traces.md
@@ -457,7 +457,7 @@ Embrace.getInstance().addSpanExporter(customDockerExporter);
 
 ### Sending Telemetry to Grafana Cloud
 
-To send telemetry to [Grafana Cloud](https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/collector/), set up the collector and add an authorization token as a header.
+To send telemetry to [Grafana Cloud](https://grafana.com/docs/opentelemetry/collector/opentelemetry-collector/), set up the collector and add an authorization token as a header.
 
 <Tabs groupId="android-language" queryString="android-language">
 <TabItem value="kotlin" label="Kotlin">

--- a/docs/android/integration/log-message-api.md
+++ b/docs/android/integration/log-message-api.md
@@ -176,7 +176,7 @@ OtlpGrpcLogRecordExporter customDockerLogRecordExporter = OtlpGrpcLogRecordExpor
 
 ### Exporting data to Grafana Cloud
 
-Embrace Logs can be exported to [Grafana Cloud](https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/collector/) using an OTel Collector.
+Embrace Logs can be exported to [Grafana Cloud](https://grafana.com/docs/opentelemetry/collector/opentelemetry-collector/) using an OTel Collector.
 
 <Tabs groupId="android-language" queryString="android-language">
 <TabItem value="kotlin" label="Kotlin">

--- a/docs/open-telemetry/integration.md
+++ b/docs/open-telemetry/integration.md
@@ -93,7 +93,7 @@ To prevent an infinite loop of network requests spans, any requests used to expo
 
 #### Sending Telemetry to Grafana Cloud
 
-To send telemetry to [Grafana Cloud](https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/collector/), set up the collector and add an authorization token as a header.
+To send telemetry to [Grafana Cloud](https://grafana.com/docs/opentelemetry/collector/opentelemetry-collector/), set up the collector and add an authorization token as a header.
 
 <Tabs groupId="android-language" queryString="android-language">
 <TabItem value="kotlin" label="Kotlin">


### PR DESCRIPTION
## Checklist before you pull:

- [ ] Double-check that any changes fit the [Embrace Docs Style Guide](https://embraceio.notion.site/Embrace-Public-Docs-Style-Guide-19f7e3c99852804abd7deacc2b14cc14).

- [ ] Please ensure that there is no customer-identifying information in text or images.

- [ ] If you renamed any pages then perhaps you likely want to add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a pair of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`

- [ ] If you link to a header within a page in the docs, make sure that header has an explicit tag. E.g., the H3 header `### Hello World {#my-explicit-id}` has an explicit tag `my-explicit-id`.
