### PR TITLE
Remove Java code examples for tracing

### DIFF
--- a/docs/android/features/traces.md
+++ b/docs/android/features/traces.md
@@ -206,6 +206,8 @@ While than one exporter for each signal can be configured, be aware of the perfo
 
 If non-trivial work is being done in the configured exporters that do not need to block the instrumentation thread, consider doing the heavy-lifting asynchronously.
 
+<Tabs groupId="android-language" queryString="android-language">
+<TabItem value="kotlin" label="Kotlin">
 ```kotlin
 Embrace.getInstance().addSpanExporter(mySpanExporter)
 Embrace.getInstance().addLogRecordExporter(myLogExporter)
@@ -232,6 +234,13 @@ You can send all or some of your telemetry to any [OpenTelemetry Collector](http
 
 To prevent an infinite loop of network requests spans, any requests used to export telemetry to OpenTelemetry Collectors should be excluded from being recorded by the Embrace SDK using the `disabled_url_patterns` setting in the Embrace Configuration file. See [this page](/android/features/configuration-file/#networking---disabled_url_patterns-string-array) for details.
 :::
+
+#### Send telemetry through GRPC
+
+To send telemetry via GRPC to a Collector endpoint, use the `OtlpGrpcSpanExporter` and specify the URL.
+
+<Tabs groupId="android-language" queryString="android-language">
+<TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
  //GRPC through an OTel Collector in a local docker image

--- a/docs/android/features/traces.md
+++ b/docs/android/features/traces.md
@@ -69,34 +69,12 @@ The `emb-` and `emb.` prefixes are reserved for internal Embrace span and attrib
 
 ### Create a span
 
-```mdx-code-block
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-```
-
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
-
 ```kotlin
 // recording will not begin until the span has been started
 val activityLoad = Embrace.getInstance().createSpan("load-activity")
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// recording will not begin until the span has been started
-EmbraceSpan activityLoad = Embrace.getInstance().createSpan("load-activity");
-```
-
-</TabItem>
-</Tabs>
-
 ### Create and start span atomically
-
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
 // activityLoad will either be a span that has already started or null if 
@@ -104,47 +82,19 @@ EmbraceSpan activityLoad = Embrace.getInstance().createSpan("load-activity");
 val activityLoad = Embrace.getInstance().startSpan("load-activity")
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// activityLoad will either be a span that has already started or null if 
-// the creation or start attempt was unsuccessful
-EmbraceSpan activityLoad = Embrace.getInstance().startSpan("load-activity");
-```
-
-</TabItem>
-</Tabs>
-
 ### Create a Span that automatically terminates
 
 By default spans do not terminate until `stop()` has been invoked. If your span might take a long time & you want it to stop when a session ends you should supply the `AutoTerminationMode` parameter when creating the span.
 
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
-
 ```kotlin
 val span = Embrace.getInstance().startSpan("my-span", AutoTerminationMode.ON_BACKGROUND)
 ```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-EmbraceSpan span = Embrace.getInstance().startSpan("my-span", AutoTerminationMode.ON_BACKGROUND);
-```
-
-</TabItem>
-</Tabs>
 
 :::info
 Spans created with `recordSpan` or `recordCompletedSpan` will stop once the function call is complete & rarely require `AutoTerminationMode`.
 :::
 
 ### Start span that tracks an operation started at an earlier time
-
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
 val appStartTimeMillis = getAppStartTime()
@@ -155,27 +105,7 @@ val appLaunchSpan = Embrace.getInstance().createSpan("app-launch")
 appLaunchSpan?.start(startTimeMs = appStartTimeMillis)
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-long appStartTimeMillis = getAppStartTime();
-EmbraceSpan activityLoad = Embrace.getInstance().createSpan("load-activity");
-
-// begin recording a span that has a different start time than 
-// the current time by starting its root span with a specific timestamp
-if (activityLoad != null) {
-    activityLoad.start(appStartTimeMillis);
-}
-```
-
-</TabItem>
-</Tabs>
-
 ### Add attributes and span events
-
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
 val embrace = Embrace.getInstance()
@@ -190,32 +120,6 @@ imageLoad?.addEvent("network-request-finished")
 // record attribute particular to this span instance
 imageLoad?.addAttribute("image-name", image.name)
 ```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-Embrace embrace = Embrace.getInstance();
-EmbraceSpan activityLoad = embrace.startSpan("load-activity");
-EmbraceSpan imageLoad = null;
-
-if (activityLoad != null) {
-    imageLoad = embrace.startSpan("load-image", activityLoad);
-}
-
-FancyImage image = fetchImage();
-
-if (imageLoad != null) {
-    // record important event at point in time
-    imageLoad.addEvent("network-request-finished");
-
-    // record attribute particular to this span instance
-    imageLoad.addAttribute("image-name", image.name);
-}
-```
-
-</TabItem>
-</Tabs>
 
 ### Add links
 
@@ -237,9 +141,6 @@ val showLoader = embrace.startSpan("showLoader")?.apply {
 
 ### Stop span for operation that ended earlier
 
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
-
 ```kotlin
 val activityLoad = Embrace.getInstance().startSpan("load-activity")
 
@@ -248,26 +149,7 @@ val activityLoad = Embrace.getInstance().startSpan("load-activity")
 activityLoad?.stop(endTimeMs = getActualEndTimeMilllis())
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-EmbraceSpan activityLoad = Embrace.getInstance().startSpan("load-activity");
-
-// some time passes after the operation being time has finished
-
-if (activityLoad != null) {
-    activityLoad.stop(getActualEndTime());
-}
-```
-
-</TabItem>
-</Tabs>
-
 ### Stop span for an operation that failed
-
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
 val activityLoad = Embrace.getInstance().startSpan("load-activity")
@@ -283,32 +165,7 @@ try {
 }
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-EmbraceSpan activityLoad = Embrace.getInstance().startSpan("load-activity");
-
-if (activityLoad != null) {
-    try {
-        loadActivity();
-    } catch (IllegalStateException e) {
-        activityLoad.addAttribute("error-message", getErrorMessage(e));
-        activityLoad.stop(ErrorCode.FAILURE);
-    } finally {
-        // calling stop on an already-stopped span will not change its state
-        activityLoad.stop();
-    }
-}
-```
-
-</TabItem>
-</Tabs>
-
 ### Add a child span
-
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
 val embrace = Embrace.getInstance()
@@ -318,26 +175,7 @@ val activityLoad = embrace.startSpan("load-activity")
 val imageLoad = activityLoad?.apply { embrace.startSpan("load-image", this) }
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-Embrace embrace = Embrace.getInstance();
-EmbraceSpan activityLoad = embrace.startSpan("load-activity");
-
-// create and start a child span if activityLoad is created and started successfully
-if (activityLoad != null) {
-    EmbraceSpan imageLoad = embrace.startSpan("load-image", activityLoad);
-}
-```
-
-</TabItem>
-</Tabs>
-
 ### Record a span for an operation that occurred in the past
-
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
 // record a span based on start and end times that are in the past
@@ -348,25 +186,7 @@ Embrace.getInstance().recordCompletedSpan(
 )
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// record a span based on start and end times that are in the past
-Embrace.getInstance().recordCompletedSpan(
-    "activity-create", 
-    startTimeMillis, 
-    endTimeMillis
-);
-```
-
-</TabItem>
-</Tabs>
-
 ### Get a reference to an in-progress span with its spanId
-
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
 val embrace = Embrace.getInstance()
@@ -378,28 +198,6 @@ val activityLoadSpanId = activityLoad?.spanId
 embrace.getSpan(activityLoadSpanId)?.stop()
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-Embrace embrace = Embrace.getInstance();
-EmbraceSpan activityLoad = embrace.startSpan("load-activity");
-String activityLoadSpanId = null;
-
-if (activityLoad != null) {
-    activityLoadSpanId = activityLoad.spanId;
-}
-
-/* some other part of the code without access to activityLoad */
-
-if (activityLoadSpanId != null) {
-    embrace.getSpan(activityLoadSpanId).stop();
-}
-```
-
-</TabItem>
-</Tabs>
-
 ## Export to OpenTelemetry Collectors
 
 Telemetry collected by the Embrace SDK can be exported as [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/) through the [SpanExporter](https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-exporter) and [LogRecordExporter](https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordexporter) interfaces. Multiple exporters can be configured, and they will receive telemetry synchronously and serially as soon as they are recorded. 
@@ -408,23 +206,10 @@ While than one exporter for each signal can be configured, be aware of the perfo
 
 If non-trivial work is being done in the configured exporters that do not need to block the instrumentation thread, consider doing the heavy-lifting asynchronously.
 
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
 ```kotlin
 Embrace.getInstance().addSpanExporter(mySpanExporter)
 Embrace.getInstance().addLogRecordExporter(myLogExporter)
 ```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-Embrace.getInstance().addSpanExporter(mySpanExporter);
-Embrace.getInstance().addLogRecordExporter(myLogExporter);
-```
-
-</TabItem>
-</Tabs>
 
 :::info
 Please note that exporters must be configured *before* the Embrace SDK is started. Exporters added after the SDK has already been started will not be used.
@@ -448,13 +233,6 @@ You can send all or some of your telemetry to any [OpenTelemetry Collector](http
 To prevent an infinite loop of network requests spans, any requests used to export telemetry to OpenTelemetry Collectors should be excluded from being recorded by the Embrace SDK using the `disabled_url_patterns` setting in the Embrace Configuration file. See [this page](/android/features/configuration-file/#networking---disabled_url_patterns-string-array) for details.
 :::
 
-#### Send telemetry through GRPC
-
-To send telemetry via GRPC to a Collector endpoint, use the `OtlpGrpcSpanExporter` and specify the URL.
-
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
-
 ```kotlin
  //GRPC through an OTel Collector in a local docker image
 val customDockerExporter = OtlpGrpcSpanExporter.builder()
@@ -464,27 +242,9 @@ val customDockerExporter = OtlpGrpcSpanExporter.builder()
 Embrace.getInstance().addSpanExporter(customDockerExporter)
 ```
 
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
- //GRPC through an OTel Collector in a local docker image
-OtlpGrpcSpanExporter customDockerExporter = OtlpGrpcSpanExporter.builder()
-    .setEndpoint("https://otel-collector.mydomain.com:4317")
-    .build();
-
-Embrace.getInstance().addSpanExporter(customDockerExporter);
-```
-
-</TabItem>
-</Tabs>
-
 #### Sending telemetry to Grafana Cloud
 
 To send telemetry to [Grafana Cloud](https://grafana.com/docs/opentelemetry/collector/opentelemetry-collector/), set up the Collector and add an authorization token as a header.
-
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
 //HTTPS to an OTel Collector in Grafana Cloud
@@ -495,22 +255,6 @@ val grafanaCloudExporter = OtlpHttpSpanExporter.builder()
 
 Embrace.getInstance().addSpanExporter(grafanaCloudExporter)
 ```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
- //HTTPS to an OTEL Collector in Grafana Cloud
-OtlpHttpSpanExporter grafanaCloudExporter = OtlpHttpSpanExporter.builder()
-    .setEndpoint("https://myinstance.grafana.net/otlp/v1/traces")
-    .addHeader("Authorization", "YourToken")
-    .build();
-
-Embrace.getInstance().addSpanExporter(grafanaCloudExporter);
-```
-
-</TabItem>
-</Tabs>
 
 ### Avoiding sending telemetry to Embrace
 

--- a/docs/android/features/traces.md
+++ b/docs/android/features/traces.md
@@ -51,7 +51,6 @@ There are no limits to the number of child spans you can have per root span, pro
 #### Exceeding limits
 If you exceed the listed limits, the operation with the limit-exceeding call will truncate the limit exceeding value, or fail in the case of API calls that would result in a count limit to be exceeded.
 
-String values are truncated by taking the first N characters such that N is the limit minus 3 (e.g. for a span name, N is 125) and appending the 3-character token `...`.  This could result in unexpected behavior if the truncated name of two spans or attribute keys end up being the same. If you detect spans with truncated names and values, consider them bugs that should be fixed.
 
 Attributes and events are truncated by taking the first N values specified and dropping the rest such that N is the limit.
 

--- a/docs/android/features/traces.md
+++ b/docs/android/features/traces.md
@@ -206,8 +206,6 @@ While than one exporter for each signal can be configured, be aware of the perfo
 
 If non-trivial work is being done in the configured exporters that do not need to block the instrumentation thread, consider doing the heavy-lifting asynchronously.
 
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
 ```kotlin
 Embrace.getInstance().addSpanExporter(mySpanExporter)
 Embrace.getInstance().addLogRecordExporter(myLogExporter)
@@ -238,9 +236,6 @@ To prevent an infinite loop of network requests spans, any requests used to expo
 #### Send telemetry through GRPC
 
 To send telemetry via GRPC to a Collector endpoint, use the `OtlpGrpcSpanExporter` and specify the URL.
-
-<Tabs groupId="android-language" queryString="android-language">
-<TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
  //GRPC through an OTel Collector in a local docker image


### PR DESCRIPTION
It's time we removed Java code examples. They are a pain to update and verify (i.e. it's ~2x the work) and provides very little utility. Android devs in 2025 can read snippets of Kotlin even if they don't use it every day, and there are a myriad of tools that can translate Kotlin to Java, including Android Studio, the very IDE most folks used to write Android app.

It's time. Nuke Java.