### PR TITLE
React Native 6.2.0 changelog

### DIFF
--- a/docs/react-native/changelog.md
+++ b/docs/react-native/changelog.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 # React Native SDK Changelog
 
 ## 6.2.0
-_July 28, 2025_
+_July 29, 2025_
 * Updated Android native Embrace SDK dependency to [version 7.6.1](/android/changelog/#761)
 
 :::info Important

--- a/docs/react-native/changelog.md
+++ b/docs/react-native/changelog.md
@@ -5,6 +5,15 @@ sidebar_position: 4
 ---
 # React Native SDK Changelog
 
+## 6.2.0
+_July 28, 2025_
+* Updated Android native Embrace SDK dependency to [version 7.6.1](/android/changelog/#761)
+
+:::info Important
+With this update desugaring is required to support Android API levels < 26. Please see [this FAQ entry](/react-native/faq/#how-do-i-support-android-api-levels--26)
+for more details.
+:::
+
 ## 6.1.0
 _May 29, 2025_
 * Added an [Expo Config Plugin](/react-native/integration/add-embrace-sdk#expo-config-plugin) for automating native

--- a/docs/react-native/faq.md
+++ b/docs/react-native/faq.md
@@ -12,6 +12,38 @@ or email us at [support@embrace.com](mailto:support@embrace.com).
 
 ## Common Questions
 
+### **How do I support Android API levels < 26?**
+
+Desugaring is required to support Android API levels < 26. To enable, the following is required in your app's
+`android/app/build.gradle`:
+
+```
+android {
+   ...  
+    compileOptions {
+        ...
+        coreLibraryDesugaringEnabled true   
+    }
+}
+
+dependencies {
+    ...
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3' // 2.0.3 or higher
+}
+```
+
+In addition, in your `android/gradle.properties` you must set
+
+```
+android.useFullClasspathForDexingTransform=true
+```
+
+Note that these settings require higher versions of Android tooling than is set by default in older versions of React
+Native application templates, specifically Gradle 8.4+ and AGP 8.3.0+. For RN versions below 0.73 you may also need to point
+to a newer version of the React Native gradle plugin. To see all the required changes you can review our
+[integration application template](https://github.com/embrace-io/embrace-react-native-sdk/tree/main/integration-tests/templates)
+for the React Native version you are using in your application.
+
 ### **Does Embrace work with Buck / OKBuck?**
 
 Not currently. Please contact us at [support@embrace.com](mailto:support@embrace.com) or on Slack if you would like to request support.


### PR DESCRIPTION
React Native 6.2.0 release + instructions for how to support lower Android API Levels