### PR TITLE
fix banner link's utm source

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -517,7 +517,7 @@ const config: Config = {
     announcementBar: {
       id: "announcement-20250821", // Change this ID when contents change so that it becomes visible to users who previously [x] hidden it
       content:
-        'Join us for a webinar on Sept 16: Exploring Embrace\'s <a target="_blank" href="https://embrace.io/docs/product/user-journeys/">User Journeys</a> product suite. <a target="_blank" href="https://get.embrace.io/user-journeys-webinar?utm_source=docs&utm_medium=docs&utm_campaign=docs-top-banner">Sign up here!</a>.',
+        'Join us for a webinar on Sept 16: Exploring Embrace\'s <a target="_blank" href="https://embrace.io/docs/product/user-journeys/">User Journeys</a> product suite. <a target="_blank" href="https://get.embrace.io/user-journeys-webinar?utm_source=website&utm_medium=docs&utm_campaign=docs-top-banner">Sign up here!</a>.',
       backgroundColor: "#EEFF04",
       isCloseable: true,
     },


### PR DESCRIPTION
## Checklist before you pull:

- [ ] Double-check that any changes fit the [Embrace Docs Style Guide](https://embraceio.notion.site/Embrace-Public-Docs-Style-Guide-19f7e3c99852804abd7deacc2b14cc14).

- [ ] Please ensure that there is no customer-identifying information in text or images.

- [ ] If you renamed any pages then perhaps you likely want to add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a pair of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`

- [ ] If you link to a header within a page in the docs, make sure that header has an explicit tag. E.g., the H3 header `### Hello World {#my-explicit-id}` has an explicit tag `my-explicit-id`.
