### PR TITLE
Fix required Java version in React Native Docs

### DIFF
--- a/docs/react-native/5x/integration/index.md
+++ b/docs/react-native/5x/integration/index.md
@@ -21,7 +21,7 @@ Note that our minimum requirements on the native side tend to be a bit higher th
 - Android: Android 7.0 (API 24)
 - `minSdkVersion`: 24 or higher
 - `compileSdkVersion`: 34 or higher
-- Java 1.8
+- Java 11
 - Kotlin 1.8.22
 - Gradle 7.5.1
 - AGP (Android Gradle Build Tools Plugin) 7.4.2

--- a/docs/react-native/integration/index.md
+++ b/docs/react-native/integration/index.md
@@ -26,7 +26,7 @@ configuration.
 - Android: Android 7.0 (API 24)
 - `minSdkVersion`: 24 or higher
 - `compileSdkVersion`: 34 or higher
-- Java 1.8
+- Java 11
 - Kotlin 1.8.22
 - Gradle 7.5.1
 - AGP (Android Gradle Build Tools Plugin) 7.4.2


### PR DESCRIPTION
Correct minimum required Java version for React Native