### PR TITLE
Update link to Embrace Docs Style Guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Checklist before you pull:
 
-- [ ] Double-check that any changes fit the [Embrace Docs Style Guide](https://embraceio.notion.site/Embrace-Public-Docs-Style-Guide-19f7e3c99852804abd7deacc2b14cc14).
+- [ ] Double-check that any changes fit the [Embrace Docs Style Guide](https://embrace.io/docs/embrace-docs-style-guide/).
 
 - [ ] Please ensure that there is no customer-identifying information in text or images.
 


### PR DESCRIPTION
Changed the link to the public docs style guide in the PR template.

## Checklist before you pull:

- [x] Double-check that any changes fit the [Embrace Docs Style Guide](https://embraceio.notion.site/Embrace-Public-Docs-Style-Guide-19f7e3c99852804abd7deacc2b14cc14).

- [x] Please ensure that there is no customer-identifying information in text or images.

- [x] If you renamed any pages then perhaps you likely want to add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a pair of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`

- [x] If you link to a header within a page in the docs, make sure that header has an explicit tag. E.g., the H3 header `### Hello World {#my-explicit-id}` has an explicit tag `my-explicit-id`.
