### PR TITLE
Fix opentelemetry-swift links

### DIFF
--- a/docs/flutter/features/traces.md
+++ b/docs/flutter/features/traces.md
@@ -122,5 +122,5 @@ try Embrace
 ```
 
 :::info
-Please note the OpenTelemetry-Swift repository does not support Cocoapods, so you will be unable to import ready-made exporters directly. We recommend adding a new file that implements a Swift [`SpanExporter`](https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/OpenTelemetrySdk/Trace/Export/SpanExporter.swift) or [`LogRecordExporter`](https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/OpenTelemetrySdk/Logs/Export/LogRecordExporter.swift) directly, and using the ready-made exporters as reference implementations.
+Please note the OpenTelemetry-Swift repository does not support Cocoapods, so you will be unable to import ready-made exporters directly. We recommend adding a new file that implements a Swift [`SpanExporter`](https://github.com/open-telemetry/opentelemetry-swift-core/blob/main/Sources/OpenTelemetrySdk/Trace/Export/SpanExporter.swift) or [`LogRecordExporter`](https://github.com/open-telemetry/opentelemetry-swift-core/blob/main/Sources/OpenTelemetrySdk/Logs/Export/LogRecordExporter.swift) directly, and using the ready-made exporters as reference implementations.
 :::

--- a/docs/ios/6x/advanced-features/opentelemetry-export.md
+++ b/docs/ios/6x/advanced-features/opentelemetry-export.md
@@ -12,7 +12,7 @@ To send traces and logs from the SDK to your collector or vendor of choice, you 
 
 ## Direct Exporters
 
-Some collectors have built or presently support direct export of traces or logs in Swift. In theory, any implementation of [`SpanExporter`](https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/OpenTelemetrySdk/Trace/Export/SpanExporter.swift) or [`LogRecordExporter`](https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/OpenTelemetrySdk/Logs/Export/LogRecordExporter.swift) that can point to the location of the collector should be able to send, respectively, spans and logs.
+Some collectors have built or presently support direct export of traces or logs in Swift. In theory, any implementation of [`SpanExporter`](https://github.com/open-telemetry/opentelemetry-swift-core/blob/main/Sources/OpenTelemetrySdk/Trace/Export/SpanExporter.swift) or [`LogRecordExporter`](https://github.com/open-telemetry/opentelemetry-swift-core/blob/main/Sources/OpenTelemetrySdk/Logs/Export/LogRecordExporter.swift) that can point to the location of the collector should be able to send, respectively, spans and logs.
 
 The OpenTelemetry-Swift repository lists [`publicly-available exporters`](https://github.com/open-telemetry/opentelemetry-swift/tree/main/Sources/Exporters) that can be added directly to your Embrace configuration. For example, here is an SDK configuration that adds a Jaeger exporter for traces:
 

--- a/docs/ios/6x/index.md
+++ b/docs/ios/6x/index.md
@@ -36,7 +36,7 @@ Whenever a Session starts, as we can see in the [`SessionController`](https://gi
     }
 ```
 
-And if we dig in a little farther, we'll see that [`EmbraceOTel`](https://github.com/embrace-io/embrace-apple-sdk/blob/main/Sources/EmbraceOTelInternal/EmbraceOTel.swift) object exists, in part, to hold an [OTel tracer](https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/OpenTelemetryApi/Trace/Tracer.swift):
+And if we dig in a little farther, we'll see that [`EmbraceOTel`](https://github.com/embrace-io/embrace-apple-sdk/blob/main/Sources/EmbraceOTelInternal/EmbraceOTel.swift) object exists, in part, to hold an [OTel tracer](https://github.com/open-telemetry/opentelemetry-swift-core/blob/main/Sources/OpenTelemetryApi/Trace/Tracer.swift):
 
 ```swift
     internal var tracer: Tracer {

--- a/docs/open-telemetry/integration.md
+++ b/docs/open-telemetry/integration.md
@@ -126,7 +126,7 @@ Embrace.getInstance().addSpanExporter(grafanaCloudExporter);
 
 ### Apple
 
-In the Embrace Apple SDK, exporters are configured at the same time that the SDK itself is configured. Any [Swift-language OTel exporter](https://github.com/open-telemetry/opentelemetry-swift/tree/main/Sources/Exporters) can be attached as an optional value when the SDK is set up in Embrace Options. Multiple span exporters can be attached during configuration by using the [`otel-swift MultiSpanExporter`](https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/OpenTelemetrySdk/Trace/Export/MultiSpanExporter.swift).
+In the Embrace Apple SDK, exporters are configured at the same time that the SDK itself is configured. Any [Swift-language OTel exporter](https://github.com/open-telemetry/opentelemetry-swift/tree/main/Sources/Exporters) can be attached as an optional value when the SDK is set up in Embrace Options. Multiple span exporters can be attached during configuration by using the [`otel-swift MultiSpanExporter`](https://github.com/open-telemetry/opentelemetry-swift-core/blob/main/Sources/OpenTelemetrySdk/Trace/Export/MultiSpanExporter.swift).
 
 ```swift
 // logging span exporter output to the Xcode console


### PR DESCRIPTION
## Checklist before you pull:

- [ ] Double-check that any changes fit the [Embrace Docs Style Guide](https://embrace.io/docs/embrace-docs-style-guide/).

- [ ] Please ensure that there is no customer-identifying information in text or images.

- [ ] If you renamed any pages then perhaps you likely want to add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a pair of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`

- [ ] If you link to a header within a page in the docs, make sure that header has an explicit tag. E.g., the H3 header `### Hello World {#my-explicit-id}` has an explicit tag `my-explicit-id`.
