### PR TITLE
[EMBR-7723] - Fixed outdated OpenTelemetry Export doc

### DIFF
--- a/docs/ios/6x/advanced-features/opentelemetry-export.md
+++ b/docs/ios/6x/advanced-features/opentelemetry-export.md
@@ -45,6 +45,7 @@ let urlConfig = URLSessionConfiguration.default
 urlConfig.httpAdditionalHeaders = ["Authorization": "Basic \(grafanaCloudTokenString)"]
 let session = URLSession(configuration: urlConfig)
 let client = BaseHTTPClient(session: session)
+
 try? Embrace
     .setup(
         options: Embrace.Options(

--- a/docs/ios/6x/advanced-features/opentelemetry-export.md
+++ b/docs/ios/6x/advanced-features/opentelemetry-export.md
@@ -43,7 +43,8 @@ For example, Grafana Cloud allows you to [generate a token](/data-destinations/g
 let grafanaCloudTokenString = //String generated from your account
 let urlConfig = URLSessionConfiguration.default
 urlConfig.httpAdditionalHeaders = ["Authorization": "Basic \(grafanaCloudTokenString)"]
-
+let session = URLSession(configuration: urlConfig)
+let client = BaseHTTPClient(session: session)
 try? Embrace
     .setup(
         options: Embrace.Options(
@@ -52,11 +53,11 @@ try? Embrace
             export: OpenTelemetryExport(
                 spanExporter: OtlpHttpTraceExporter(
                     endpoint: URL(string: "https://otlp-gateway-prod-us-west-0.grafana.net/otlp/v1/traces")!,
-                    useSession: URLSession(configuration: urlConfig)
+                    httpClient: client
                 ),
                 logExporter: OtlpHttpLogExporter(
                     endpoint: URL(string: "https://otlp-gateway-prod-us-west-0.grafana.net/otlp/v1/logs")!,
-                    useSession: URLSession(configuration: urlConfig)
+                    httpClient: client
                 )
             )
         )


### PR DESCRIPTION
Document has an example using `OtlpHttpTraceExporter` that's now outdated since Otel has updated their API.