### PR TITLE
Remove android implementation detail

### DIFF
--- a/docs/android/legacy-integration/session-reporting.md
+++ b/docs/android/legacy-integration/session-reporting.md
@@ -51,7 +51,7 @@ your application. During the next application launch the previous session will b
 
 In addition to the application lifecycle events that will automatically end a session, the Embrace SDK also lets you manually end sessions in code, if that fits your use-case.
 
-Triggering the [`endSession`](https://github.com/embrace-io/embrace-android-sdk/blob/main/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SessionApiDelegate.kt#L44) method will end the session and immediately start a new session (no additional instrumentation is required). When ending a session manually, the SDK takes a boolean argument whether or not to clear all user info on the device, as below:
+Triggering the `endSession` method will end the session and immediately start a new session (no additional instrumentation is required). When ending a session manually, the SDK takes a boolean argument whether or not to clear all user info on the device, as below:
 
 ```kotlin
   // scenario in which app session is ended manually


### PR DESCRIPTION
## Description of changes

Avoid linking to implementation details of the Android codebase as the link was brittle and changed in the course of a refactor.
