### PR TITLE
Changed Announcement Banner and Fixed broken Onelogin link

### DIFF
--- a/docs/product/settings/sso.md
+++ b/docs/product/settings/sso.md
@@ -85,11 +85,11 @@ Embrace application is published in Okta's Integration Network, which simplifies
 
 The following SAML attributes are supported:
 
-| Name | Value |
-|--------|--------|
+| Name      | Value          |
+| --------- | -------------- |
 | FirstName | user.firstName |
-| LastName | user.lastName |
-| Email | user.email |
+| LastName  | user.lastName  |
+| Email     | user.email     |
 
 ### Optional Attributes
 
@@ -97,9 +97,9 @@ Role- and project-based provisioning can be enabled by the Embrace team at the o
 
 Once support has enabled the feature for your org, you may add the following attributes to your SAML assertion:
 
-| Attribute | Description |
-|-----------|-------------|
-| `Role` | Maps IdP group values to Embrace roles. Values containing `admin` resolve to Admin; values containing `member`/`user` resolve to Member. |
+| Attribute  | Description                                                                                                                                                    |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Role`     | Maps IdP group values to Embrace roles. Values containing `admin` resolve to Admin; values containing `member`/`user` resolve to Member.                       |
 | `Projects` | Scopes Member access to specific projects. Each value should be `<project_external_id>[:grant]` where grant is `manage`, `edit`, or `view` (default `manage`). |
 
 Project external IDs are the short hashes shown in the dashboard URL and the project settings page.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -490,20 +490,20 @@ const config: Config = {
           },
           {
             to: "/metrics-forwarding/metrics-api/",
-            from: "/embrace-api/"
+            from: "/embrace-api/",
           },
           {
             to: "/metrics-forwarding/metrics-api/grafana-integration",
-            from: "/embrace-api/grafana_integrations"
+            from: "/embrace-api/grafana_integrations",
           },
           {
             to: "/metrics-forwarding/metrics-api/code-samples",
-            from: "/embrace-api/code_samples"
+            from: "/embrace-api/code_samples",
           },
           {
             to: "/product/web-vitals",
-            from: "/product/core-web-vitals"
-          }
+            from: "/product/core-web-vitals",
+          },
         ],
       },
     ],
@@ -559,13 +559,12 @@ const config: Config = {
     },
 
     announcementBar: {
-      id: "announcement-20251112", // Change this ID when contents change so that it becomes visible to users who previously [x] hidden it
+      id: "announcement-20260414", // Change this ID when contents change so that it becomes visible to users who previously [x] hidden it
       content:
-        '<a target="_blank" href="https://embrace.io/blog/speedcurve-joins-embrace/?utm_source=website&utm_medium=website&utm_campaign=docs-banner">Embrace acquires SpeedCurve, expands user-focused observability platform with web performance insights.</a>',
+        '<a target="_blank" href="https://get.embrace.io/ai-powered-observability?utm_source=website&utm_medium=website&utm_campaign=docs-banner">LIVE SESSION on April 29: Less toil, faster fixes: AI-powered observability with Embrace</a>',
       backgroundColor: "#EEFF04",
       isCloseable: true,
     },
-
 
     navbar: {
       logo: {


### PR DESCRIPTION
## Description of changes

This PR changes the announcement banner link as well as fixes a broken onelogin link that was causing lychee to fail.

## Checklist before you pull:

- [x] Double-check that any changes fit the [Embrace Docs Style Guide](https://embrace.io/docs/embrace-docs-style-guide/).
- [x] Please ensure that there is no customer-identifying information in text or images.
- [x] If you changed any doc file names, add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a set of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`.
- [x] If you link to a header within a page in the docs, make sure that header has an explicit tag in case it changes in the future. E.g., the H3 header `### Hello World {#my-explicit-id}` has an explicit tag `my-explicit-id`.
