### PR TITLE
chore: add W3C Performance API docs (EMBR-11901)

### DIFF
--- a/docs/web/automatic-instrumentation/index.md
+++ b/docs/web/automatic-instrumentation/index.md
@@ -32,6 +32,7 @@ The Embrace SDK includes the following automatic instrumentation capabilities:
 - **[React](./react/index.md)** - Various instrumentations that emit React specific telemetry if your app is built on that
 framework
 - **[Empty Root Node](./empty-root-node.md)** - Records when content fails to render on the page's root element
+- **[W3C Performance API](./w3c-performance-api/index.md)** - Captures user timing marks and measures, element render timings, and server-side timing hints from the browser Performance API
 
 ### Configuring Automatic Instrumentation
 

--- a/docs/web/automatic-instrumentation/w3c-performance-api/element-timing.md
+++ b/docs/web/automatic-instrumentation/w3c-performance-api/element-timing.md
@@ -7,12 +7,14 @@ sidebar_position: 2
 ## Element Timing
 
 The Embrace SDK automatically captures render and load timing for elements you explicitly opt into
-tracking by adding the `elementtiming` HTML attribute. This gives you fine-grained visibility into
-when key elements — images, hero text, call-to-action blocks — become visible on screen.
+tracking by adding the [`elementtiming`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/elementtiming)
+HTML attribute. This gives you fine-grained visibility into when key elements — images, hero text,
+call-to-action blocks — become visible on screen.
 
 ### How Element Timing Instrumentation Works
 
-The SDK observes `PerformanceElementTiming` entries via a `PerformanceObserver`. Each observed entry
+The SDK observes [`PerformanceElementTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceElementTiming)
+entries via a `PerformanceObserver`. Each observed entry
 is emitted as a span, using the element's `identifier` (the `elementtiming` attribute value) as the
 span name, and the `renderTime` or `loadTime` as the span boundaries.
 

--- a/docs/web/automatic-instrumentation/w3c-performance-api/element-timing.md
+++ b/docs/web/automatic-instrumentation/w3c-performance-api/element-timing.md
@@ -1,0 +1,48 @@
+---
+title: Element Timing
+description: Automatically track render and load timing for annotated elements with Embrace
+sidebar_position: 2
+---
+
+## Element Timing
+
+The Embrace SDK automatically captures render and load timing for elements you explicitly opt into
+tracking by adding the `elementtiming` HTML attribute. This gives you fine-grained visibility into
+when key elements — images, hero text, call-to-action blocks — become visible on screen.
+
+### How Element Timing Instrumentation Works
+
+The SDK observes `PerformanceElementTiming` entries via a `PerformanceObserver`. Each observed entry
+is emitted as a span, using the element's `identifier` (the `elementtiming` attribute value) as the
+span name, and the `renderTime` or `loadTime` as the span boundaries.
+
+To instrument an element, add the `elementtiming` attribute with a descriptive identifier:
+
+```html
+<img src="/hero.jpg" elementtiming="hero-image" />
+<h1 elementtiming="page-heading">Welcome</h1>
+```
+
+The SDK captures all annotated elements automatically — no additional SDK configuration is needed.
+
+### Data Captured
+
+For each element timing entry, the SDK captures:
+
+- The `elementtiming` identifier
+- `renderTime` — when the element was painted on screen (ms from navigation start); `0` for cross-origin elements
+- `loadTime` — when the element's resource finished loading (ms from navigation start); `0` for text elements
+- `startTime` — `renderTime` when non-zero, otherwise `loadTime`
+- The HTML tag name (e.g. `img`, `p`)
+- The resource URL, natural width, and natural height (for image elements)
+
+### Browser Support
+
+Element timing is a Chromium-only feature. The instrumentation is silently skipped in Firefox and
+Safari — no error is thrown and no data is lost on those browsers.
+
+### Integration with Other Features
+
+- Element timing spans are associated with the current session and page
+- Custom dashboards can be built to monitor render time, load time, and start time percentiles per identifier
+- Alerts can be set on render times exceeding specific thresholds

--- a/docs/web/automatic-instrumentation/w3c-performance-api/index.md
+++ b/docs/web/automatic-instrumentation/w3c-performance-api/index.md
@@ -1,0 +1,32 @@
+---
+title: W3C Performance API
+description: Automatically capture browser performance timing data with Embrace
+sidebar_position: 8
+---
+
+## W3C Performance API
+
+The Embrace SDK automatically collects timing data from the browser's [Performance API](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API),
+giving you visibility into how your application and its resources perform in real user environments.
+
+### Available Instrumentations
+
+- **[User Timing](./user-timing.md)** - Captures custom performance marks and measures created by your application via `performance.mark()` and `performance.measure()`
+- **[Element Timing](./element-timing.md)** - Tracks render and load timing for elements annotated with the `elementtiming` attribute
+- **[Server Timing](./server-timing.md)** - Reads backend performance hints sent via the `Server-Timing` HTTP response header on navigation requests
+
+### Opting Out
+
+Each instrumentation is always-on by default. Individual instrumentations can be disabled via the `omit` option when initializing the SDK:
+
+```typescript
+import { initSDK } from '@embrace-io/web-sdk';
+
+initSDK({
+  appID: "YOUR_EMBRACE_APP_ID",
+  appVersion: "YOUR_APP_VERSION",
+  defaultInstrumentationConfig: {
+    omit: new Set(['user-timing', 'element-timing', 'server-timing']),
+  },
+});
+```

--- a/docs/web/automatic-instrumentation/w3c-performance-api/server-timing.md
+++ b/docs/web/automatic-instrumentation/w3c-performance-api/server-timing.md
@@ -14,7 +14,7 @@ contributors — database queries, cache lookups, CDN processing — alongside y
 ### How Server Timing Instrumentation Works
 
 When the page finishes loading, the SDK reads `performance.getEntriesByType('navigation')[0].serverTiming`
-and emits one log per `PerformanceServerTiming` entry. If the navigation entry has no server timing
+and emits one log per [`PerformanceServerTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceServerTiming) entry. If the navigation entry has no server timing
 data, the SDK no-ops silently.
 
 No changes to your frontend code are required. Visibility depends on your server emitting the header:

--- a/docs/web/automatic-instrumentation/w3c-performance-api/server-timing.md
+++ b/docs/web/automatic-instrumentation/w3c-performance-api/server-timing.md
@@ -1,0 +1,44 @@
+---
+title: Server Timing
+description: Automatically capture backend performance hints from Server-Timing headers with Embrace
+sidebar_position: 3
+---
+
+## Server Timing
+
+The Embrace SDK automatically reads backend performance metrics sent by your server via the
+[`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing) HTTP
+response header on the navigation request. This gives you visibility into server-side latency
+contributors — database queries, cache lookups, CDN processing — alongside your frontend telemetry.
+
+### How Server Timing Instrumentation Works
+
+When the page finishes loading, the SDK reads `performance.getEntriesByType('navigation')[0].serverTiming`
+and emits one log per `PerformanceServerTiming` entry. If the navigation entry has no server timing
+data, the SDK no-ops silently.
+
+No changes to your frontend code are required. Visibility depends on your server emitting the header:
+
+```
+Server-Timing: db;dur=78, cache;desc="HIT";dur=0, render;dur=163
+```
+
+### Known Limitation
+
+`serverTiming` is only populated for same-origin navigations, or cross-origin navigations where the
+server includes the `Timing-Allow-Origin` response header. When neither condition is met, the array
+is empty and the SDK no-ops silently.
+
+### Data Captured
+
+For each `Server-Timing` entry, the SDK captures:
+
+- `name` — the metric name (e.g. `db`, `cache`, `cfEdge`)
+- `description` — the `desc` parameter value; in practice carries high-cardinality data such as cache status, country codes, and request IDs
+- `duration` — milliseconds; `0` when the server omits the `dur` parameter (common for metadata-only entries)
+
+### Integration with Other Features
+
+- Server timing logs are associated with the current session and page navigation
+- Custom dashboards can be built to monitor duration percentiles per metric name, and filter by description values
+- Alerts can be set on server-side latencies exceeding specific thresholds

--- a/docs/web/automatic-instrumentation/w3c-performance-api/user-timing.md
+++ b/docs/web/automatic-instrumentation/w3c-performance-api/user-timing.md
@@ -1,0 +1,61 @@
+---
+title: User Timing
+description: Automatically capture custom performance marks and measures with Embrace
+sidebar_position: 1
+---
+
+## User Timing
+
+The Embrace SDK automatically captures custom performance marks and measures created by your application
+via `performance.mark()` and `performance.measure()`, giving you visibility into your own timing
+instrumentation without any extra backend work.
+
+### How User Timing Instrumentation Works
+
+The SDK observes `PerformanceMark` and `PerformanceMeasure` entries via a `PerformanceObserver`.
+Marks are emitted as logs and measures are emitted as spans, reflecting their different shapes: a mark
+is a discrete point in time, while a measure has a defined start and duration.
+
+To keep data volumes manageable, the SDK deduplicates entries by name per page URL — only the first
+occurrence of a given name is captured per navigation. A cap of 200 marks and 100 measures per page
+is applied after deduplication.
+
+### Data Captured
+
+For each mark, the SDK captures:
+
+- The mark name and timestamp
+- The entry type (`mark`)
+- Any `detail` object provided via `performance.mark()`, serialized as the log body
+
+For each measure, the SDK captures:
+
+- The measure name (used as the span name) and start time
+- The duration
+- The entry type (`measure`)
+- Any `detail` object provided via `performance.measure()`, attached as a span attribute
+
+### Filtering Entries
+
+You can limit which entries are captured using the `allowedEntries` option, which accepts either an
+array of names or a predicate function:
+
+```typescript
+import { initSDK } from '@embrace-io/web-sdk';
+
+initSDK({
+  appID: "YOUR_EMBRACE_APP_ID",
+  appVersion: "YOUR_APP_VERSION",
+  defaultInstrumentationConfig: {
+    'user-timing': {
+      allowedEntries: ['my-app-measure', 'checkout-flow'],
+    },
+  },
+});
+```
+
+### Integration with Other Features
+
+- User timing marks and measures are associated with the current session and page
+- Custom dashboards can be built to monitor percentile durations and start times, filtered by name, entry type, or `detail` attributes
+- Alerts can be set on measure durations exceeding specific thresholds

--- a/docs/web/automatic-instrumentation/w3c-performance-api/user-timing.md
+++ b/docs/web/automatic-instrumentation/w3c-performance-api/user-timing.md
@@ -7,12 +7,15 @@ sidebar_position: 1
 ## User Timing
 
 The Embrace SDK automatically captures custom performance marks and measures created by your application
-via `performance.mark()` and `performance.measure()`, giving you visibility into your own timing
-instrumentation without any extra backend work.
+via [`performance.mark()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and
+[`performance.measure()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure),
+giving you visibility into your own timing instrumentation without any extra backend work.
 
 ### How User Timing Instrumentation Works
 
-The SDK observes `PerformanceMark` and `PerformanceMeasure` entries via a `PerformanceObserver`.
+The SDK observes [`PerformanceMark`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMark)
+and [`PerformanceMeasure`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMeasure)
+entries via a `PerformanceObserver`.
 Marks are emitted as logs and measures are emitted as spans, reflecting their different shapes: a mark
 is a discrete point in time, while a measure has a defined start and duration.
 


### PR DESCRIPTION
## Summary

- Adds a new **W3C Performance API** section under Automatic Instrumentation
- Three new pages: User Timing, Element Timing, and Server Timing
- Updates the Automatic Instrumentation index to list the new section