### PR TITLE
document that hang detection is opt-in

### DIFF
--- a/docs/ios/6x/api-reference/capture-services.md
+++ b/docs/ios/6x/api-reference/capture-services.md
@@ -22,7 +22,7 @@ The SDK includes the following built-in capture services:
 - **LowMemoryWarningCaptureService** - Detects low memory warnings
 - **LowPowerModeCaptureService** - Tracks low power mode
 - **PushNotificationCaptureService** - Captures push notification events
-- **HangCaptureService** - Captures app hangs
+- **HangCaptureService** - Captures app hangs (**opt-in** — not included in the defaults)
 
 ### NetworkCaptureService
 
@@ -185,9 +185,16 @@ This service doesn't have configurable options.
 
 Captures app hangs.
 
+**This service is opt-in.** It is not added by `EmbraceIO.CaptureServicesOptions.default()` nor by `CaptureServiceBuilder.addDefaults()` — you must register it explicitly:
+
+- With `EmbraceIO`: `CaptureServicesOptionsBuilder().addDefaults().addHangCaptureService().build()`
+- With `Embrace`: `CaptureServiceBuilder().addDefaults().add(HangCaptureService()).build()`
+
 This service is turned off when attached to a debugger (ie: while debugging in Xcode). You can enable it when connected to a debugger by setting the `EMBAllowWatchdogInDebugger` environment var to `1`.
 
-**GitHub Source**: [EmbraceCaptureService](https://github.com/embrace-io/embrace-apple-sdk/blob/main/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift)
+For full configuration details (including `HangLimits`), see [Hang Detection](../automatic-instrumentation/hang-detection.md).
+
+**GitHub Source**: [HangCaptureService](https://github.com/embrace-io/embrace-apple-sdk/blob/main/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift)
 
 ### Custom Capture Services
 
@@ -342,7 +349,7 @@ let services = CaptureServiceBuilder()
     .add(.pushNotification(options: pushOptions))
     .add(.lowMemoryWarning)
     .add(.lowPowerMode)
-    .add(.hangWatchdog)
+    .add(HangCaptureService()) // opt-in
     .build()
 
 let options = EmbraceIO.Options.withAppId(
@@ -363,7 +370,7 @@ let services = CaptureServiceBuilder()
     .add(.pushNotification(options: pushOptions))
     .add(.lowMemoryWarning)
     .add(.lowPowerMode)
-    .add(.hangWatchdog)
+    .add(HangCaptureService()) // opt-in
     .build()
 
 let options = Embrace.Options(

--- a/docs/ios/6x/automatic-instrumentation/hang-detection.md
+++ b/docs/ios/6x/automatic-instrumentation/hang-detection.md
@@ -41,14 +41,69 @@ The SDK automatically monitors the main thread using a dedicated watchdog thread
 
 ### Key Benefits
 
-- Automatically detect UI freezes and unresponsive behavior
+- Detect UI freezes and unresponsive behavior
 - Identify code causing main thread blockages
 - Track hang frequency and duration
-- No code changes required
 
-### Configuration
+### Enabling Hang Detection
 
-Hang detection is enabled by default. You can customize settings during development or testing by implementing a custom `EmbraceConfigurable`:
+Starting with the framerate-based hang detector introduced in 6.x, **hang detection is opt-in**. It is not installed by `EmbraceIO.CaptureServicesOptions.default()` and is not added by `CaptureServiceBuilder.addDefaults()`. You must register the service explicitly when you set up the SDK.
+
+<Tabs groupId="embrace-client">
+<TabItem value="embraceio" label="EmbraceIO" default>
+
+```swift
+import EmbraceIO
+
+let captureServices = CaptureServicesOptionsBuilder()
+    .addDefaults()
+    .addHangCaptureService()
+    .build()
+
+let options = EmbraceIO.Options.withAppId(
+    "YOUR_APP_ID",
+    captureServices: captureServices
+)
+
+do {
+    try EmbraceIO.setup(options: options)
+    try EmbraceIO.shared.start()
+} catch {
+    print("Failed to set up Embrace: \(error)")
+}
+```
+
+</TabItem>
+<TabItem value="embrace" label="Embrace">
+
+```swift
+import EmbraceIO
+import EmbraceCore
+
+let services = CaptureServiceBuilder()
+    .addDefaults()
+    .add(HangCaptureService())
+    .build()
+
+let options = Embrace.Options(
+    appId: "YOUR_APP_ID",
+    captureServices: services
+)
+
+do {
+    try Embrace.setup(options: options)
+    try Embrace.client?.start()
+} catch {
+    print("Failed to set up Embrace: \(error)")
+}
+```
+
+</TabItem>
+</Tabs>
+
+### Tuning HangLimits
+
+You can customize how many hangs are captured per session and how many stack-trace samples are taken during each hang by implementing a custom `EmbraceConfigurable`:
 
 <Tabs groupId="embrace-client">
 <TabItem value="embraceio" label="EmbraceIO" default>
@@ -223,12 +278,13 @@ context.perform {
 
 ### Disabling Hang Detection
 
-Set `hangPerSession: 0` in your configuration to disable hang detection.
+Hang detection is off by default. To turn it off after enabling it, either remove the `addHangCaptureService()` / `add(HangCaptureService())` call from your setup, or set `hangPerSession: 0` in your configuration.
 
 ### Troubleshooting
 
 #### Not Seeing Hang Data
 
+- Confirm the `HangCaptureService` was registered at setup (`addHangCaptureService()` or `add(HangCaptureService())`) — it is not part of the defaults
 - Verify `hangPerSession > 0`
 - Confirm SDK is properly initialized
 - Test with `Thread.sleep(forTimeInterval: 0.5)` on the main thread

--- a/docs/ios/6x/automatic-instrumentation/index.md
+++ b/docs/ios/6x/automatic-instrumentation/index.md
@@ -30,9 +30,13 @@ The Embrace SDK includes the following automatic instrumentation capabilities:
 - **[Tap Capture](./tap-capture.md)** - Records user interactions with your app's interface
 - **[Push Notifications](./push-notifications.md)** - Captures push notification events received by your app
 - **[WebView Monitoring](./webview-monitoring.md)** - Tracks URL loads and errors in `WKWebView` components
-- **[Hang Detection](./hang-detection.md)** - Monitors main thread hangs and UI freezes with stack trace sampling
+- **[Hang Detection](./hang-detection.md)** - Monitors main thread hangs and UI freezes with stack trace sampling (**opt-in**)
 
 Additionally, the SDK monitors system events like low memory warnings and low power mode to help you understand environmental impacts on your app's performance.
+
+:::info
+Hang Detection is the one built-in service that is **not** included in `addDefaults()` or `EmbraceIO.CaptureServicesOptions.default()`. You must register it explicitly. See [Hang Detection](./hang-detection.md) for setup.
+:::
 
 ### How Capture Services Work
 

--- a/docs/ios/6x/overview/key-features.md
+++ b/docs/ios/6x/overview/key-features.md
@@ -21,7 +21,7 @@ The SDK automatically instruments several aspects of your app with minimal confi
 - **Tap Capture**: Records user interactions with your app through UI touch events
 - **Push Notifications**: Tracks push notification receipt and handling
 - **WebView Monitoring**: Monitors WKWebView URL loading and error events
-- **Hang Detection**: Monitors main thread hangs and UI freezes to identify unresponsive behavior
+- **Hang Detection** (opt-in): Monitors main thread hangs and UI freezes to identify unresponsive behavior
 
 ### Error and Crash Reporting
 


### PR DESCRIPTION
The framerate-based hang detector shipped in embrace-apple-sdk PR #556 (88b12c4e) flipped the default for EmbraceIO.CaptureServicesOptions.hang from true to false. HangCaptureService is no longer registered by CaptureServicesOptions.default() or
  CaptureServiceBuilder.addDefaults(), so customers must add it explicitly. The 6.x docs still claimed it was on by default and used an internal .hangWatchdog helper in an example. This PR corrects both.