### PR TITLE
fix: move onBrokenMarkdownLinks to markdown.hooks config

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -26,9 +26,14 @@ const config: Config = {
   projectName: "embrace-docs", // Usually your repo name.
 
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
   onDuplicateRoutes: "throw",
   onBrokenAnchors: "throw",
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks:"throw"
+    }
+  },
 
   i18n: {
     defaultLocale: "en",


### PR DESCRIPTION
## Description of changes

Resolves the Docusaurus deprecation warning by moving `onBrokenMarkdownLinks` from the top-level config into the new `markdown.hooks` config object.

## Checklist before you pull:

- [x] Double-check that any changes fit the [Embrace Docs Style Guide](https://embrace.io/docs/embrace-docs-style-guide/).
- [x] Please ensure that there is no customer-identifying information in text or images.
- [ ] If you changed any doc file names, add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a set of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`.
- [ ] If you link to a header within a page in the docs, make sure that header has an explicit tag in case it changes in the future. E.g., the H3 header `### Hello World {#my-explicit-id}` has an explicit tag `my-explicit-id`.