### PR TITLE
chore: add prettier config for markdown formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Build output and generated files
+build
+.docusaurus
+node_modules
+
+# Lockfiles and caches
+package-lock.json
+.lycheecache
+
+# Prettier mangles snake_case identifiers next to *emphasis* in these
+# config reference tables (e.g. `app_id *string*` -> `app*id \_string*`)
+docs/android/configuration/configuration-file.md
+docs/ios/5x/features/configuration-file.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "bracketSameLine": true,
+  "singleQuote": true
+}

--- a/docs/web/getting-started/basic-setup.md
+++ b/docs/web/getting-started/basic-setup.md
@@ -74,6 +74,7 @@ app version into your bundle at build time. The process is done as part of [uplo
 We recommend you include our SDK as a regular npm dependency (see above). If you prefer to include the SDK as a code
 snippet from CDN, you can do so by adding the following script tag to your main HTML file:
 
+<!-- prettier-ignore -->
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@embrace-io/web-sdk@X.X.X" crossorigin="anonymous"></script>
 ```
@@ -110,6 +111,7 @@ the following example:
 If you prefer to load the SDK asynchronously to avoid blocking the rendering of your page, you'll need to add the
 following snippet to your HTML file. Remember to replace `X.X.X` with the version of the SDK you want to include:
 
+<!-- prettier-ignore -->
 ```html
 <script>
    !function(){window.EmbraceWebSdkOnReady=window.EmbraceWebSdkOnReady||{q:[],onReady:function(e){window.EmbraceWebSdkOnReady.q.push(e)}};let e=document.createElement("script");e.async=!0,e.crossOrigin="anonymous",e.src="https://cdn.jsdelivr.net/npm/@embrace-io/web-sdk@X.X.X",e.onload=function(){window.EmbraceWebSdkOnReady.q.forEach(e=>e()),window.EmbraceWebSdkOnReady.q=[],window.EmbraceWebSdkOnReady.onReady=function(e){e()}};let n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)}();

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "lychee": "lychee --no-progress --cache --max-cache-age 1d --root-dir docs --fallback-extensions md docs/"
+    "lychee": "lychee --no-progress --cache --max-cache-age 1d --root-dir docs --fallback-extensions md docs/",
+    "format": "prettier --write \"{docs,shared}/**/*.{md,mdx}\"",
+    "format:check": "prettier --check \"{docs,shared}/**/*.{md,mdx}\""
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.1",


### PR DESCRIPTION
## Description of changes

Adds Prettier configuration to standardize markdown formatting across the docs repo.

- Adds `.prettierrc.json` with formatting rules
- Adds `.prettierignore` to exclude files from formatting
- Wires up a Prettier script in `package.json`
- Applies formatting to `docs/web/getting-started/basic-setup.md`

## Checklist before you pull:

- [x] Double-check that any changes fit the [Embrace Docs Style Guide](https://embrace.io/docs/embrace-docs-style-guide/).
- [x] Please ensure that there is no customer-identifying information in text or images.
- [x] If you changed any doc file names, add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a set of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`.
- [x] If you link to a header within a page in the docs, make sure that header has an explicit tag in case it changes in the future. E.g., the H3 header `### Hello World {#my-explicit-id}` has an explicit tag `my-explicit-id`.