### PR TITLE
style(web): format docs with prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Build output and generated files
+build
+.docusaurus
+node_modules
+
+# Lockfiles and caches
+package-lock.json
+.lycheecache
+
+# Prettier mangles snake_case identifiers next to *emphasis* in these
+# config reference tables (e.g. `app_id *string*` -> `app*id \_string*`)
+docs/android/configuration/configuration-file.md
+docs/ios/5x/features/configuration-file.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "bracketSameLine": true,
+  "singleQuote": true
+}

--- a/docs/web/advanced-features/network-spans-forwarding.md
+++ b/docs/web/advanced-features/network-spans-forwarding.md
@@ -26,19 +26,19 @@ the additional header by configuring the fetch or XHR instrumentations with an a
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   defaultInstrumentationConfig: {
     '@opentelemetry/instrumentation-fetch': {
       propagateTraceHeaderCorsUrls: [
         /example\.com/, // propagates for any CORS requests with URLs that match the regex
-        "https://www.example.com/foo", // propagates for CORS requests to URLs that exactly match the string
+        'https://www.example.com/foo', // propagates for CORS requests to URLs that exactly match the string
       ],
     },
     '@opentelemetry/instrumentation-xml-http-request': {
       propagateTraceHeaderCorsUrls: [
         /example\.com/, // propagates for any CORS requests with URLs that match the regex
-        "https://www.example.com/foo", // propagates for CORS requests to URLs that exactly match the string
+        'https://www.example.com/foo', // propagates for CORS requests to URLs that exactly match the string
       ],
     },
   },
@@ -54,8 +54,8 @@ turned off if set:
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
 
   // The following are not supported alongside Network Span Forwarding and will cause that feature to turn off:
   // 1. Setting registerGlobally to false
@@ -64,7 +64,10 @@ initSDK({
   propagator: myCustomPropagator,
   // 3. Omitting both network instrumentations
   defaultInstrumentationConfig: {
-    omit: new Set(['@opentelemetry/instrumentation-fetch', '@opentelemetry/instrumentation-xml-http-request']),
+    omit: new Set([
+      '@opentelemetry/instrumentation-fetch',
+      '@opentelemetry/instrumentation-xml-http-request',
+    ]),
   },
 });
 ```
@@ -78,8 +81,8 @@ of what has been configured server-side:
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
 
   blockNetworkSpanForwarding: true,
 });

--- a/docs/web/advanced-features/opentelemetry-export.md
+++ b/docs/web/advanced-features/opentelemetry-export.md
@@ -21,31 +21,34 @@ appropriate CORS headers in its responses:
 
 ```typescript
 import { initSDK } from '@embrace-io/web-sdk';
-import { OTLPLogExporter }   from '@opentelemetry/exporter-logs-otlp-http';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   spanExporters: [
     new OTLPTraceExporter({
       url: 'https://example.com/endpoint/for/traces',
       headers: {
-        'Authorization': 'Basic TOKEN'
-      }
+        Authorization: 'Basic TOKEN',
+      },
     }),
   ],
   logExporters: [
     new OTLPLogExporter({
       url: 'https://example.com/endpoint/for/logs',
       headers: {
-        'Authorization': 'Basic TOKEN'
-      }
+        Authorization: 'Basic TOKEN',
+      },
     }),
   ],
   defaultInstrumentationConfig: {
     network: {
-      ignoreUrls: ['https://example.com/endpoint/for/traces', 'https://example.com/endpoint/for/logs'],
+      ignoreUrls: [
+        'https://example.com/endpoint/for/traces',
+        'https://example.com/endpoint/for/logs',
+      ],
     },
   },
 });

--- a/docs/web/automatic-instrumentation/empty-root-node.md
+++ b/docs/web/automatic-instrumentation/empty-root-node.md
@@ -22,8 +22,8 @@ This instrumentation can be enabled by configuring it with the element that is c
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   defaultInstrumentationConfig: {
     'empty-root': {
       rootNode: document.getElementById('root'),

--- a/docs/web/automatic-instrumentation/exceptions.md
+++ b/docs/web/automatic-instrumentation/exceptions.md
@@ -30,5 +30,5 @@ Exception tracking integrates with other Embrace features:
 
 - Exceptions are associated with the current session
 - Individual exception instances are grouped together in the Embrace Dashboard if they are triggered by the same
-underlying code
+  underlying code
 - Alerts can be set on exception rates or to be notified if a previously resolved exception has resurfaced

--- a/docs/web/automatic-instrumentation/index.md
+++ b/docs/web/automatic-instrumentation/index.md
@@ -30,7 +30,7 @@ The Embrace SDK includes the following automatic instrumentation capabilities:
 - **[Document Load](./document-load.md)** - Provides insight into your app's page load performance
 - **[User Interactions](./user-interactions.md)** - Records user interactions within your app's pages
 - **[React](./react/index.md)** - Various instrumentations that emit React specific telemetry if your app is built on that
-framework
+  framework
 - **[Empty Root Node](./empty-root-node.md)** - Records when content fails to render on the page's root element
 - **[W3C Performance API](./w3c-performance-api/index.md)** - Captures user timing marks and measures, element render timings, and server-side timing hints from the browser Performance API
 
@@ -43,13 +43,13 @@ behavior by passing a `defaultInstrumentationConfig` object when initializing th
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   defaultInstrumentationConfig: {
     omit: new Set(['@opentelemetry/instrumentation-fetch']),
     'web-vital': {
-      trackingLevel: 'all'
-    }
+      trackingLevel: 'all',
+    },
   },
 });
 ```
@@ -66,8 +66,8 @@ other packages to instrument specific aspects of your application:
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   instrumentations: [myCustomInstrumentation],
 });
 ```

--- a/docs/web/automatic-instrumentation/react/index.md
+++ b/docs/web/automatic-instrumentation/react/index.md
@@ -1,5 +1,5 @@
 ---
-title: React  
+title: React
 description: Automatically track React specific telemetry in your web app with Embrace
 sidebar_position: 6
 ---

--- a/docs/web/automatic-instrumentation/react/react-router.md
+++ b/docs/web/automatic-instrumentation/react/react-router.md
@@ -18,10 +18,8 @@ import { createReactRouterNavigationInstrumentation } from '@embrace-io/web-sdk/
 
 initSDK({
   // ...Other configs
-  instrumentations: [
-    createReactRouterNavigationInstrumentation(),
-  ],
-})
+  instrumentations: [createReactRouterNavigationInstrumentation()],
+});
 ```
 
 ### React Router V4/V5
@@ -129,20 +127,21 @@ const customNavigationHandler = () => {
   // ... navigation logic
 
   // Get raw URL and path pattern from the custom navigation
-  const url = '/path/before/replaced'
-  const path = '/path/before/:replace'
+  const url = '/path/before/replaced';
+  const path = '/path/before/:replace';
 
   // Since `createReactRouterNavigationInstrumentation` was already called when setting up the
   // instrumentation in `initSDK` this will simply get a reference to the NavigationInstrumentation
   // instance rather than creating a new one
-  const navigationInstrumentation = createReactRouterNavigationInstrumentation();
+  const navigationInstrumentation =
+    createReactRouterNavigationInstrumentation();
 
   // Track that the navigation occurred
   navigationInstrumentation.setCurrentRoute({
     url,
-    path
+    path,
   });
-}
+};
 ```
 
 ## Configuration

--- a/docs/web/automatic-instrumentation/w3c-performance-api/index.md
+++ b/docs/web/automatic-instrumentation/w3c-performance-api/index.md
@@ -23,8 +23,8 @@ Each instrumentation is always-on by default. Individual instrumentations can be
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   defaultInstrumentationConfig: {
     omit: new Set(['user-timing', 'element-timing', 'server-timing']),
   },

--- a/docs/web/automatic-instrumentation/w3c-performance-api/user-timing.md
+++ b/docs/web/automatic-instrumentation/w3c-performance-api/user-timing.md
@@ -47,8 +47,8 @@ array of names or a predicate function:
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   defaultInstrumentationConfig: {
     'user-timing': {
       allowedEntries: ['my-app-measure', 'checkout-flow'],

--- a/docs/web/automatic-instrumentation/web-vitals.md
+++ b/docs/web/automatic-instrumentation/web-vitals.md
@@ -37,7 +37,7 @@ For each Web Vital, the SDK captures:
 Web Vitals integrates with other Embrace features:
 
 - Web Vital reports are associated with the current session and, if possible, correlated with page load information
-and user interactions
+  and user interactions
 - Performance dashboards monitor Web Vitals and surface issues on particular pages
 - Alerts can be set on Web Vital scores exceeding specific thresholds
 

--- a/docs/web/best-practices/debugging-tips.md
+++ b/docs/web/best-practices/debugging-tips.md
@@ -17,8 +17,8 @@ For debugging purposes, increase the log level during development to see detaile
 import { initSDK, DiagLogLevel } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   logLevel: DiagLogLevel.INFO,
 });
 ```
@@ -33,14 +33,14 @@ If you're experiencing issues with SDK initialization:
    import { initSDK } from '@embrace-io/web-sdk';
 
    const result = initSDK({
-     appID: "YOUR_EMBRACE_APP_ID",
-     appVersion: "YOUR_APP_VERSION",
+     appID: 'YOUR_EMBRACE_APP_ID',
+     appVersion: 'YOUR_APP_VERSION',
    });
 
    if (result) {
-     console.log("Successfully initialized the Embrace SDK");
+     console.log('Successfully initialized the Embrace SDK');
    } else {
-     console.log("Failed to initialize the Embrace SDK");
+     console.log('Failed to initialize the Embrace SDK');
    }
    ```
 
@@ -70,10 +70,10 @@ If your custom traces aren't appearing:
 1. Add more context to your spans to make them easier to identify:
 
    ```typescript
-   const span = trace.startSpan("span-name", {
-      attributes: {
-         "debug-id": id,
-      },
+   const span = trace.startSpan('span-name', {
+     attributes: {
+       'debug-id': id,
+     },
    });
 
    // ... operations ...
@@ -85,9 +85,9 @@ If your custom traces aren't appearing:
    ```typescript
    import { trace } from '@embrace-io/web-sdk';
 
-   const parentSpan = trace.startSpan("parent-operation");
+   const parentSpan = trace.startSpan('parent-operation');
    // Correct - child span is related to parent
-   const childSpan = trace.startSpan("the-child", { parentSpan });
+   const childSpan = trace.startSpan('the-child', { parentSpan });
 
    // ... operations ...
    childSpan.end();
@@ -99,7 +99,7 @@ If your custom traces aren't appearing:
 3. Ensure that spans were ended, spans must be ended in order to be reported to Embrace
 
    ```typescript
-   const span = trace.startSpan("span-name");
+   const span = trace.startSpan('span-name');
 
    // ... operations ...
 

--- a/docs/web/best-practices/index.md
+++ b/docs/web/best-practices/index.md
@@ -16,4 +16,4 @@ these best practices will ensure optimal performance, security, and user experie
 - **[Debugging Tips](./debugging-tips.md)** - Strategies for troubleshooting issues with the SDK
 
 By following these best practices, you'll maximize the value of the Embrace SDK while minimizing any potential negative
-impact on your application's performance or user experience.  
+impact on your application's performance or user experience.

--- a/docs/web/best-practices/performance-optimization.md
+++ b/docs/web/best-practices/performance-optimization.md
@@ -15,11 +15,11 @@ Be mindful of the number and size of custom attributes you add to sessions, logs
 
 ```typescript
 // Good practice: use small, relevant attributes
-session.addProperty("user-tier", "premium");
+session.addProperty('user-tier', 'premium');
 
 // Avoid: large string values or too many attributes
 // This could impact memory usage
-session.addProperty("user-full-details", largeJSONString);
+session.addProperty('user-full-details', largeJSONString);
 ```
 
 ### Avoid Excessive Logging
@@ -44,17 +44,17 @@ onTableScroll(() => {
 For operations that may generate many spans, consider representing using a single parent span:
 
 ```typescript
-const processItems = items => {
+const processItems = (items) => {
   // Start a parent span...
-  const span = trace.startSpan("process-items-batch");
+  const span = trace.startSpan('process-items-batch');
 
   // ...instead of starting/ending many small spans
-  items.forEach(item => {
+  items.forEach((item) => {
     processItem(item);
   });
 
   // End the parent span
-  span.end()
+  span.end();
 };
 ```
 
@@ -65,17 +65,16 @@ For very high-volume operations, consider implementing trace sampling to reduce 
 ```typescript
 // Only trace some percentage of a high-frequency operation
 function highFrequencyOperation() {
-
   // Simple sampling approach
   const shouldTrace = Math.random() < 0.1; // 10% sample rate
 
   if (shouldTrace) {
-    const span = trace.startSpan("high-frequency-operation");
+    const span = trace.startSpan('high-frequency-operation');
 
     // Perform operation
     // ...
 
-    span.end()
+    span.end();
   } else {
     // Just perform operation without tracing
   }

--- a/docs/web/best-practices/security-considerations.md
+++ b/docs/web/best-practices/security-considerations.md
@@ -21,7 +21,7 @@ in particular they will:
 
 - Redact credentials in URLs passed in the form of `https://username:password@www.example.com/`
 - Redact any query string values for keys that are considered sensitive (defined in the SDK as
-[`DEFAULT_SENSITIVE_TOKENS`](https://github.com/embrace-io/embrace-web-sdk/blob/5020e9ca919e7088a7ef42cc6ac9caaebfd1f370/src/sdk/defaultAttributeScrubbers.ts#L12))
+  [`DEFAULT_SENSITIVE_TOKENS`](https://github.com/embrace-io/embrace-web-sdk/blob/5020e9ca919e7088a7ef42cc6ac9caaebfd1f370/src/sdk/defaultAttributeScrubbers.ts#L12))
 
 This process can be customized by specifying additional sensitive query string keys to check for with
 `additionalQueryParamsToScrub`:
@@ -30,9 +30,9 @@ This process can be customized by specifying additional sensitive query string k
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
-  additionalQueryParamsToScrub: ['my-senstive-key', 'foo-token']
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
+  additionalQueryParamsToScrub: ['my-senstive-key', 'foo-token'],
 });
 ```
 
@@ -42,10 +42,10 @@ Custom attribute scrubbers can also be supplied to perform redactions on other a
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   attributeScrubbers: [
-    { key: 'sensitive-attribute', scrub: value => '[REDACTED]' },
+    { key: 'sensitive-attribute', scrub: (value) => '[REDACTED]' },
   ],
 });
 ```
@@ -67,13 +67,13 @@ option:
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   defaultInstrumentationConfig: {
     network: {
       ignoreUrls: [/sensitive-path/, 'https://auth.example.com/sensitive/'],
     },
-  }
+  },
 });
 ```
 
@@ -89,13 +89,13 @@ option:
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   defaultInstrumentationConfig: {
     click: {
       shouldTrack: (element) => !element.dataset.sensitive,
-    }
-  }
+    },
+  },
 });
 ```
 
@@ -106,19 +106,19 @@ particular element using its `innerTextForElement` option:
 import { initSDK } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   defaultInstrumentationConfig: {
     click: {
-      innerTextForElement: element => {
+      innerTextForElement: (element) => {
         if (element.dataset.sensitive) {
           return 'REDACTED';
         } else {
           return element.innerText;
         }
       },
-    }
-  }
+    },
+  },
 });
 ```
 
@@ -144,7 +144,7 @@ When setting user identifiers, avoid using direct PII:
 
 ```typescript
 // DON'T: Use direct PII as identifier
-user.setUserId("john.smith@example.com");
+user.setUserId('john.smith@example.com');
 
 // DO: Use hashed or tokenized identifiers
 const hashedEmail = hashFunction(userEmail);
@@ -159,16 +159,16 @@ Consider implementing mechanisms to respect user privacy choices:
 
 ```typescript
 function updatePrivacyConsent(userConsented: boolean) {
-    if (userConsented) {
-      // Start Embrace with user consent
-      initSDK({
-        appID: "YOUR_EMBRACE_APP_ID",
-        appVersion: "YOUR_APP_VERSION",
-      });
-    } else {
-      // If user does not consent, don't start Embrace
-      // or limit what you collect
-    }
+  if (userConsented) {
+    // Start Embrace with user consent
+    initSDK({
+      appID: 'YOUR_EMBRACE_APP_ID',
+      appVersion: 'YOUR_APP_VERSION',
+    });
+  } else {
+    // If user does not consent, don't start Embrace
+    // or limit what you collect
+  }
 }
 ```
 

--- a/docs/web/core-concepts/logs.md
+++ b/docs/web/core-concepts/logs.md
@@ -60,10 +60,10 @@ how to instrument your application.
 ### Logs vs Other Concepts
 
 - **Logs vs Traces**: While traces focus on performance and operation flow, logs provide contextual information about
-events and states
+  events and states
 - **Logs vs Sessions**: Logs are events within a session that provide additional context
 - **Logs vs Breadcrumbs**: Logs are more detailed, are grouped based on message, and can have alerts built on top of
-their aggregation. Breadcrumbs are simpler standalone markers of user journey steps
+  their aggregation. Breadcrumbs are simpler standalone markers of user journey steps
 
 ### Best Practices
 

--- a/docs/web/core-concepts/sessions.md
+++ b/docs/web/core-concepts/sessions.md
@@ -18,7 +18,7 @@ A new session starts when your web app is loaded in a user's browser tab and is 
 
 - The tab or browser is closed or refreshed
 - The user switches to another tab or the browser's window loses focuses. If background sessions are enabled this also
-starts a new background session
+  starts a new background session
 - There is no user activity detected on the tab for a certain period of time (30 minutes by default)
 
 A session ending will trigger an upload of that session's data to Embrace where it will be shown within the Embrace
@@ -67,21 +67,21 @@ To add a property to the current session:
 ```typescript
 import { session } from '@embrace-io/web-sdk';
 
-session.addProperty("my-custom-property", "some value");
+session.addProperty('my-custom-property', 'some value');
 ```
 
 To add a permanent property to current and future sessions in all tabs and windows:
 
 ```typescript
-session.addProperty("my-custom-property", "some value", {
-  lifespan: 'permanent'
+session.addProperty('my-custom-property', 'some value', {
+  lifespan: 'permanent',
 });
 ```
 
 To remove a property:
 
 ```typescript
-session.removeProperty("my-custom-property");
+session.removeProperty('my-custom-property');
 ```
 
 #### Limits on Properties

--- a/docs/web/core-concepts/traces-spans.md
+++ b/docs/web/core-concepts/traces-spans.md
@@ -12,7 +12,7 @@ Traces are a powerful feature in the Embrace Web SDK that give you complete visi
 
 In the Embrace SDK (built on OpenTelemetry):
 
-- A **trace** represents an entire operation or workflow in your application  
+- A **trace** represents an entire operation or workflow in your application
 - A **span** represents a single unit of work within that trace
 - Spans can be nested, forming parent-child relationships to create a trace
 
@@ -30,7 +30,7 @@ With the Embrace Traces API, you can:
 ### Trace Limits
 
 | Type                               | Limit           |
-| ---------------------------------- |-----------------|
+| ---------------------------------- | --------------- |
 | Max number of spans per session    | 1,000           |
 | Max number of attributes per span  | 50              |
 | Max number of events per span      | 10              |

--- a/docs/web/core-concepts/user-identification.md
+++ b/docs/web/core-concepts/user-identification.md
@@ -23,7 +23,7 @@ For tracking specific users across sessions, you can assign a unique identifier:
 ```typescript
 import { user } from '@embrace-io/web-sdk';
 
-user.setUserId("user-12345");
+user.setUserId('user-12345');
 ```
 
 :::warning Note on Privacy

--- a/docs/web/getting-started/basic-setup.md
+++ b/docs/web/getting-started/basic-setup.md
@@ -74,6 +74,7 @@ app version into your bundle at build time. The process is done as part of [uplo
 We recommend you include our SDK as a regular npm dependency (see above). If you prefer to include the SDK as a code
 snippet from CDN, you can do so by adding the following script tag to your main HTML file:
 
+<!-- prettier-ignore -->
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@embrace-io/web-sdk@X.X.X" crossorigin="anonymous"></script>
 ```
@@ -110,6 +111,7 @@ the following example:
 If you prefer to load the SDK asynchronously to avoid blocking the rendering of your page, you'll need to add the
 following snippet to your HTML file. Remember to replace `X.X.X` with the version of the SDK you want to include:
 
+<!-- prettier-ignore -->
 ```html
 <script>
    !function(){window.EmbraceWebSdkOnReady=window.EmbraceWebSdkOnReady||{q:[],onReady:function(e){window.EmbraceWebSdkOnReady.q.push(e)}};let e=document.createElement("script");e.async=!0,e.crossOrigin="anonymous",e.src="https://cdn.jsdelivr.net/npm/@embrace-io/web-sdk@X.X.X",e.onload=function(){window.EmbraceWebSdkOnReady.q.forEach(e=>e()),window.EmbraceWebSdkOnReady.q=[],window.EmbraceWebSdkOnReady.onReady=function(e){e()}};let n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)}();

--- a/docs/web/getting-started/basic-setup.md
+++ b/docs/web/getting-started/basic-setup.md
@@ -32,14 +32,14 @@ capturing telemetry:
 import { initSDK } from '@embrace-io/web-sdk';
 
 const result = initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
 });
 
 if (result) {
-  console.log("Successfully initialized the Embrace SDK");
+  console.log('Successfully initialized the Embrace SDK');
 } else {
-  console.log("Failed to initialize the Embrace SDK");
+  console.log('Failed to initialize the Embrace SDK');
 }
 ```
 
@@ -58,10 +58,10 @@ you use your `package.json` to track versions of your app then a way to keep thi
 value when initializing the SDK (assuming that your bundler provides a method for importing json files):
 
 ```typescript
-import * as packageInfo from "../<some-path>/package.json";
+import * as packageInfo from '../<some-path>/package.json';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
+  appID: 'YOUR_EMBRACE_APP_ID',
   appVersion: packageInfo.version,
 });
 ```
@@ -88,23 +88,23 @@ that makes use of the sdk.
 The rest of this documentation assumes using the SDK from an NPM installation, here are some required changes to keep in
 mind as you refer to further instructions:
 
-1) Importing the SDK from node modules is no longer valid. Instead, reference it from the global `window` object:
+1. Importing the SDK from node modules is no longer valid. Instead, reference it from the global `window` object:
 
    ```javascript
-     const { initSDK, log, page, session, trace, user } = window.EmbraceWebSdk;
+   const { initSDK, log, page, session, trace, user } = window.EmbraceWebSdk;
    ```
 
-2) Our CLI tool does not support injecting an app version when loading from CDN since in that case our SDK is not
+2. Our CLI tool does not support injecting an app version when loading from CDN since in that case our SDK is not
 
 bundled with your code, instead you will need to make sure to pass in your app version when initializing the SDK as in
 the following example:
 
-   ```javascript
-   initSDK({
-     appVersion: '0.0.1',
-     /*...*/
-   });
-   ```
+```javascript
+initSDK({
+  appVersion: '0.0.1',
+  /*...*/
+});
+```
 
 #### Async CDN Loading
 
@@ -122,11 +122,11 @@ By deferring the loading of the SDK, any early calls to the SDK need to be wrapp
 
 ```javascript
 window.EmbraceWebSdkOnReady.onReady(() => {
-   window.EmbraceWebSdk.initSDK({
-      appVersion: '0.0.1',
-      /*...*/
-   });
-})
+  window.EmbraceWebSdk.initSDK({
+    appVersion: '0.0.1',
+    /*...*/
+  });
+});
 ```
 
 This is necessary to ensure that the SDK is fully loaded before you start using it.
@@ -152,10 +152,10 @@ OpenTelemetry 1.x support is limited to 1.x versions of the SDK, which are depre
 If you wish to customize the SDK behavior by configuring custom resources, exporters, processors, or instrumentations,
 you must ensure that you are using versions of the OTel packages that are compatible with our SDK:
 
-| Embrace Web SDK | Open Telemetry APIs | Core   | Instrumentations & Contrib |
-|-----------------|---------------------|--------|----------------------------|
-| `^2.0.0`        | `^1.9.0`            | `^2.0.3` | `>=0.203.0 <0.300.0`     |
-| `1.8.2`         | `^1.9.0`            | `1.30.1` | `0.57.2`                 |
+| Embrace Web SDK | Open Telemetry APIs | Core     | Instrumentations & Contrib |
+| --------------- | ------------------- | -------- | -------------------------- |
+| `^2.0.0`        | `^1.9.0`            | `^2.0.3` | `>=0.203.0 <0.300.0`       |
+| `1.8.2`         | `^1.9.0`            | `1.30.1` | `0.57.2`                   |
 
 For a full list of dependencies used by the SDK, please refer to the [package.json](https://github.com/embrace-io/embrace-web-sdk/blob/main/package.json) file in the SDK repository.
 
@@ -168,8 +168,8 @@ initializing as follows:
 import { initSDK, DiagLogLevel } from '@embrace-io/web-sdk';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   logLevel: DiagLogLevel.ALL,
 });
 ```
@@ -181,12 +181,18 @@ emitted:
 
 ```typescript
 import { initSDK, DiagLogLevel } from '@embrace-io/web-sdk';
-import { ConsoleLogRecordExporter, SimpleLogRecordProcessor } from '@opentelemetry/sdk-logs';
-import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-web'
+import {
+  ConsoleLogRecordExporter,
+  SimpleLogRecordProcessor,
+} from '@opentelemetry/sdk-logs';
+import {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-web';
 
 initSDK({
-  appID: "YOUR_EMBRACE_APP_ID",
-  appVersion: "YOUR_APP_VERSION",
+  appID: 'YOUR_EMBRACE_APP_ID',
+  appVersion: 'YOUR_APP_VERSION',
   logLevel: DiagLogLevel.INFO,
 
   // setup as exporters to output with the same batching as when exporting to a collector endpoint

--- a/docs/web/manual-instrumentation/breadcrumbs.md
+++ b/docs/web/manual-instrumentation/breadcrumbs.md
@@ -15,7 +15,7 @@ Here's how you add a breadcrumb to the session:
 ```typescript
 import { session } from '@embrace-io/web-sdk';
 
-session.addBreadcrumb("something happened");
+session.addBreadcrumb('something happened');
 ```
 
 :::info Character Limit
@@ -51,13 +51,13 @@ Use clear, consistent naming for your breadcrumbs:
 import { session } from '@embrace-io/web-sdk';
 
 // Good: Clear and descriptive
-session.addBreadcrumb("User started checkout process");
-session.addBreadcrumb("Payment validation failed");
-session.addBreadcrumb("Order confirmation displayed");
+session.addBreadcrumb('User started checkout process');
+session.addBreadcrumb('Payment validation failed');
+session.addBreadcrumb('Order confirmation displayed');
 
 // Avoid: Vague or inconsistent
-session.addBreadcrumb("Something happened");
-session.addBreadcrumb("Error");
+session.addBreadcrumb('Something happened');
+session.addBreadcrumb('Error');
 ```
 
 #### Performance Considerations

--- a/docs/web/manual-instrumentation/custom-logging.md
+++ b/docs/web/manual-instrumentation/custom-logging.md
@@ -25,7 +25,7 @@ Embrace supports multiple log severity levels:
 - **Info**: General information about app operation
 - **Warning**: Potential issues that didn't prevent functionality
 - **Error**: Issues that affected functionality but didn't cause an exception to be thrown. See
-[Logging Handled Exceptions](#logging-handled-exceptions) below for dealing with actual Error  
+  [Logging Handled Exceptions](#logging-handled-exceptions) below for dealing with actual Error
 
 objects
 
@@ -43,8 +43,8 @@ log.message('Purchase attempt failed', 'error', {
   attributes: {
     productID,
     price,
-    paymentMethod: "card",
-  }
+    paymentMethod: 'card',
+  },
 });
 ```
 
@@ -64,7 +64,7 @@ try {
   log.logException(e as Error, {
     attributes: {
       errorCode: '301',
-    }
+    },
   });
 }
 ```

--- a/docs/web/manual-instrumentation/custom-traces.md
+++ b/docs/web/manual-instrumentation/custom-traces.md
@@ -28,7 +28,7 @@ The simplest way to create a span is with the `startSpan` method:
 ```typescript
 import { trace } from '@embrace-io/web-sdk';
 
-const span = trace.startSpan("span-name");
+const span = trace.startSpan('span-name');
 
 someAsyncOperation()
   .then(() => span.end())
@@ -43,14 +43,14 @@ Add context to your spans with attributes:
 import { trace } from '@embrace-io/web-sdk';
 
 // Adding attributes on start is recommended if they are known at that point
-const span = trace.startSpan("span-name", {
+const span = trace.startSpan('span-name', {
   attributes: {
-    "my-attr-on-create": "hello",
+    'my-attr-on-create': 'hello',
   },
 });
 
 // But they can also be added later on if needed as long as the span hasn't been ended
-span.setAttribute("my-other-attr", "bye");
+span.setAttribute('my-other-attr', 'bye');
 ```
 
 :::info
@@ -64,8 +64,8 @@ Create parent-child relationships between spans to represent nested operations:
 ```typescript
 import { trace } from '@embrace-io/web-sdk';
 
-const parentSpan = trace.startSpan("the-parent");
-const childSpan = trace.startSpan("the-child", { parentSpan });
+const parentSpan = trace.startSpan('the-parent');
+const childSpan = trace.startSpan('the-child', { parentSpan });
 
 await someNestedOperation();
 childSpan.end();
@@ -84,10 +84,10 @@ a full child span you can instead add an event to the span:
 ```typescript
 import { trace } from '@embrace-io/web-sdk';
 
-const span = trace.startSpan("span-name");
+const span = trace.startSpan('span-name');
 
-span.addEvent("something-happened", {
-  "some-event-attr": "event-attr-value",
+span.addEvent('something-happened', {
+  'some-event-attr': 'event-attr-value',
 });
 ```
 
@@ -98,9 +98,11 @@ Sometimes you need to create a span for an operation that has already completed:
 ```typescript
 import { trace } from '@embrace-io/web-sdk';
 
-trace.startSpan("span-name", {
-  startTime: previouslyStartedTime,
-}).end(previouslyEndedTime);
+trace
+  .startSpan('span-name', {
+    startTime: previouslyStartedTime,
+  })
+  .end(previouslyEndedTime);
 ```
 
 ### Best Practices
@@ -126,11 +128,11 @@ Choose an appropriate level of granularity for your spans:
 Add attributes that would be useful for troubleshooting:
 
 ```typescript
-trace.startSpan("span-name", {
+trace.startSpan('span-name', {
   attributes: {
-    "user-tier": "premium",
-    "data-size": dataSize.description,
-    "retry-count": retryCount.description
-  }
+    'user-tier': 'premium',
+    'data-size': dataSize.description,
+    'retry-count': retryCount.description,
+  },
 });
 ```

--- a/docs/web/manual-instrumentation/index.md
+++ b/docs/web/manual-instrumentation/index.md
@@ -59,13 +59,13 @@ The most common way to start with manual instrumentation is by creating custom s
 import { trace } from '@embrace-io/web-sdk';
 
 // Create and start a span
-const span = trace.startSpan("span-name");
+const span = trace.startSpan('span-name');
 
 // Perform your operation
 // ...
 
 // Add some context to the span
-span.setAttribute("operation-size", "large");
+span.setAttribute('operation-size', 'large');
 
 // Record success or failure
 if (success) {

--- a/docs/web/manual-instrumentation/navigation.md
+++ b/docs/web/manual-instrumentation/navigation.md
@@ -20,10 +20,8 @@ import { getNavigationInstrumentation } from '@embrace-io/web-sdk';
 
 initSDK({
   // ...Other configs
-  instrumentations: [
-    getNavigationInstrumentation(),
-  ],
-})
+  instrumentations: [getNavigationInstrumentation()],
+});
 ```
 
 Then hook into your navigation tooling and let the instrumentation know when a route changes through the
@@ -32,20 +30,19 @@ Then hook into your navigation tooling and let the instrumentation know when a r
 ```typescript
 import { getNavigationInstrumentation } from '@embrace-io/web-sdk';
 
-
 const customNavigationHandler = () => {
   // ... navigation logic
 
   // Get raw URL and path pattern from the navigation tooling
-  const url = '/path/before/replaced'
-  const path = '/path/before/:replace'
+  const url = '/path/before/replaced';
+  const path = '/path/before/:replace';
 
   const navigationInstrumentation = getNavigationInstrumentation();
 
   // Track that the navigation occurred
   navigationInstrumentation.setCurrentRoute({
     url,
-    path
+    path,
   });
-}
+};
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "lychee": "lychee --no-progress --cache --max-cache-age 1d --root-dir docs --fallback-extensions md docs/"
+    "lychee": "lychee --no-progress --cache --max-cache-age 1d --root-dir docs --fallback-extensions md docs/",
+    "format": "prettier --write \"{docs,shared}/**/*.{md,mdx}\"",
+    "format:check": "prettier --check \"{docs,shared}/**/*.{md,mdx}\""
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.1",


### PR DESCRIPTION
## Description of changes

This PR applies Prettier formatting to all Web SDK docs under `docs/web`. It is purely mechanical reformatting (no content changes) produced by the Prettier config introduced in the base branch `overbalance/add-prettier-config`.

## Checklist before you pull:

- [x] Double-check that any changes fit the [Embrace Docs Style Guide](https://embrace.io/docs/embrace-docs-style-guide/).
- [x] Please ensure that there is no customer-identifying information in text or images.
- [x] If you changed any doc file names, add a redirect from old to new URL so that we don't end up with broken links. You can do this by adding a set of to/from values in `docusaurus.config.js` under `@docusaurus/plugin-client-redirects`.
- [x] If you link to a header within a page in the docs, make sure that header has an explicit tag in case it changes in the future. E.g., the H3 header `### Hello World {#my-explicit-id}` has an explicit tag `my-explicit-id`.
