### PR TITLE
fix(docs): convert self-referential embrace.io URLs to internal links

### DIFF
--- a/docs/dpa/subprocessors.md
+++ b/docs/dpa/subprocessors.md
@@ -7,7 +7,7 @@ hide_table_of_contents: true
 ## Subprocessors
 
 The following is a list of subprocessors that Embrace may engage to provide its services. Depending on the region configured for your account or application, one or more entities below
-may be used in the course of processing of Personal Data, as defined by the [Data Processing Addendum](https://embrace.io/docs/dpa/) under Embrace's [Terms of Service](https://embrace.io/docs/terms-of-service/).
+may be used in the course of processing of Personal Data, as defined by the [Data Processing Addendum](/dpa/) under Embrace's [Terms of Service](/terms-of-service/).
 
 ### United States
 

--- a/docs/flutter/upgrading.md
+++ b/docs/flutter/upgrading.md
@@ -16,7 +16,7 @@ The Android SDK has been updated to the latest major version. These changes affe
     }
 ```
 
-If you've written additional Android code as part of your integration, you may need to perform additional migrations. See the [Android](https://embrace.io/docs/android/upgrading/) upgrade guide for more information.
+If you've written additional Android code as part of your integration, you may need to perform additional migrations. See the [Android](/android/upgrading/) upgrade guide for more information.
 
 ## Upgrade from 2.0.0 to 3.0.0
 

--- a/docs/product/web-vitals.md
+++ b/docs/product/web-vitals.md
@@ -63,7 +63,7 @@ The stacked column chart shows how the split of Good, Needs Improvement and Poor
 
 <img src={require('@site/static/images/web-vitals/lcp-distribution-over-time.png').default} alt="Screenshot of stacked column chart showing the rating for LCP over time" />
 
-At the bottom of the dashboard is a table showing examples of LCP measurements. Clicking on a row takes you to the [User Timeline](https://embrace.io/docs/product/sessions/user-timeline/) for the chosen example.
+At the bottom of the dashboard is a table showing examples of LCP measurements. Clicking on a row takes you to the [User Timeline](/product/sessions/user-timeline/) for the chosen example.
 
 <img src={require('@site/static/images/web-vitals/lcp-examples.png').default} alt="Screenshot of table showing examples of the LCP measurements " />
 

--- a/docs/unity/changelog.md
+++ b/docs/unity/changelog.md
@@ -11,7 +11,7 @@ sidebar_position: 4
 *November 25, 2025*
 
 Embrace Android SDK Version: [7.5.0](/android/changelog/#750)
-Embrace Apple SDK Version: [6.15.1](/ios/changelog/#6141)
+Embrace Apple SDK Version: [6.15.1](/ios/changelog/#6151)
 
 - Upgraded Embrace Apple SDK version to 6.15.1
 - Removed broken reference to `getSessionProperties()`; it is now a no-op and marked as deprecated.

--- a/docs/unity/changelog.md
+++ b/docs/unity/changelog.md
@@ -10,8 +10,8 @@ sidebar_position: 4
 
 *November 25, 2025*
 
-Embrace Android SDK Version: [7.5.0](https://embrace.io/docs/android/changelog/#750)
-Embrace Apple SDK Version: [6.15.1](https://embrace.io/docs/ios/changelog/#6141)
+Embrace Android SDK Version: [7.5.0](/android/changelog/#750)
+Embrace Apple SDK Version: [6.15.1](/ios/changelog/#6141)
 
 - Upgraded Embrace Apple SDK version to 6.15.1
 - Removed broken reference to `getSessionProperties()`; it is now a no-op and marked as deprecated.
@@ -20,8 +20,8 @@ Embrace Apple SDK Version: [6.15.1](https://embrace.io/docs/ios/changelog/#6141)
 
 ### 2.8.0
 
-Embrace Android SDK Version: [7.5.0](https://embrace.io/docs/android/changelog/#750)
-Embrace Apple SDK Version: [6.14.1](https://embrace.io/docs/ios/changelog/#6141)
+Embrace Android SDK Version: [7.5.0](/android/changelog/#750)
+Embrace Apple SDK Version: [6.14.1](/ios/changelog/#6141)
 
 *November 10, 2025*
 
@@ -33,8 +33,8 @@ Embrace Apple SDK Version: [6.14.1](https://embrace.io/docs/ios/changelog/#6141)
 
 ### 2.7.0
 
-Embrace Android SDK Version: [7.5.0](https://embrace.io/docs/android/changelog/#750)
-Embrace Apple SDK Version: [6.8.4](https://embrace.io/docs/ios/changelog/#684)
+Embrace Android SDK Version: [7.5.0](/android/changelog/#750)
+Embrace Apple SDK Version: [6.8.4](/ios/changelog/#684)
 
 *September 4, 2025*
 
@@ -46,8 +46,8 @@ Both options are opt-in and low overhead. Please try them!
 
 ### 2.6.0
 
-Embrace Android SDK Version: [7.5.0](https://embrace.io/docs/android/changelog/#750)
-Embrace Apple SDK Version [6.8.4](https://embrace.io/docs/ios/changelog/#684)
+Embrace Android SDK Version: [7.5.0](/android/changelog/#750)
+Embrace Apple SDK Version [6.8.4](/ios/changelog/#684)
 
 *August 14, 2025*
 
@@ -63,8 +63,8 @@ All are opt-in and low overhead. Please try them out!
 
 ### 2.5.0
 
-Embrace Android SDK Version: [7.3.0](https://embrace.io/docs/android/changelog/#730)
-Embrace Apple SDK Version [6.8.4](https://embrace.io/docs/ios/changelog/#684)
+Embrace Android SDK Version: [7.3.0](/android/changelog/#730)
+Embrace Apple SDK Version [6.8.4](/ios/changelog/#684)
 
 *June 16, 2025*
 


### PR DESCRIPTION
## Description of changes

Converts hardcoded `https://embrace.io/docs/...` links that point back into this docs site into root-relative internal links (e.g. `/dpa/`, `/android/upgrading/`). This keeps in-site navigation relative so links resolve correctly across environments and previews. Also corrects the iOS 6.15.1 changelog anchor in the Unity changelog (`#6141` → `#6151`).

Files touched:
- `docs/dpa/subprocessors.md`
- `docs/flutter/upgrading.md`
- `docs/product/web-vitals.md`
- `docs/unity/changelog.md`

## Checklist before you pull:

- [x] Double-check that any changes fit the [Embrace Docs Style Guide](https://embrace.io/docs/embrace-docs-style-guide/).
- [x] Please ensure that there is no customer-identifying information in text or images.
- [x] If you changed any doc file names, add a redirect from old to new URL so that we don't end up with broken links. (No file names changed.)
- [x] If you link to a header within a page in the docs, make sure that header has an explicit tag in case it changes in the future.