### PR TITLE
style(docs): format android and unity docs with prettier

### DIFF
--- a/docs/android/changelog.md
+++ b/docs/android/changelog.md
@@ -12,13 +12,13 @@ Please review the [Upgrade Guide](/android/upgrading/) when moving from one majo
 
 ### 8.3.1
 
-*April 24, 2026*
+_April 24, 2026_
 
 - Fix crash that occurs when calling a subset of API methods after disabling the SDK with the `disable()` method
 
 ### 8.3.0
 
-*April 23, 2026*
+_April 23, 2026_
 
 - Fix the start time of cold app start root spans
 - Delete unsent session data that is older than 7 days
@@ -27,13 +27,13 @@ Please review the [Upgrade Guide](/android/upgrading/) when moving from one majo
 
 ### 8.2.1
 
-*April 17, 2026*
+_April 17, 2026_
 
 - Fix the start time of cold app start root spans
 
 ### 8.2.0
 
-*March 13, 2026*
+_March 13, 2026_
 
 :::info Important
 This release uses the official OpenTelemetry Kotlin API (`io.opentelemetry.kotlin`), switching from the Embrace Kotlin OTel API (`io.embrace.opentelemetry.kotlin`) from which the new API is based. Please change your dependencies if you explicitly referenced the old Embrace Kotlin OTel API in your app.
@@ -57,7 +57,7 @@ This release also requires `embrace-config.json` to ONLY contain valid keys. The
 
 ### 8.1.0
 
-*January 12, 2026*
+_January 12, 2026_
 
 - Added support for setting an OpenTelemetry SpanProcessor and LogRecordProcessor
 - Added support for using OpenTelemetry's Logger API
@@ -66,7 +66,7 @@ This release also requires `embrace-config.json` to ONLY contain valid keys. The
 
 ### 8.0.0
 
-*December 4, 2025*
+_December 4, 2025_
 
 - New minimum versions for platform dependencies like Gradle, AGP, Kotlin, and JDK.
   - Better support of new versions of these dependencies going forward, including the upcoming Kotlin 2.3
@@ -78,26 +78,26 @@ This release also requires `embrace-config.json` to ONLY contain valid keys. The
 
 ### 7.9.3
 
-*November 11, 2025*
+_November 11, 2025_
 
 - Fix method signature mismatch in HttpsURLConnection instrumentation wrapper
 - Added deprecation warning: this is the last version with the `io.embrace.swazzler` gradle plugin ID. From 8.0, the ID will be `io.embrace.gradle`
 
 ### 7.9.2
 
-*October 20, 2025*
+_October 20, 2025_
 
 - Propagate arguments correctly when starting span directly via OTel API
 
 ### 7.9.1
 
-*August 29, 2025*
+_August 29, 2025_
 
 - Restore the minimum Java runtime compatibility version to 1.8
 
 ### 7.9.0
 
-*August 27, 2025*
+_August 27, 2025_
 
 :::info Important
 This release bumped the minimum runtime Java version to 11. Compatibility with 1.8 is restored in 7.9.1.
@@ -107,7 +107,7 @@ This release bumped the minimum runtime Java version to 11. Compatibility with 1
 
 ### 7.8.0
 
-*August 11, 2025*
+_August 11, 2025_
 
 :::info Important
 This release bumped the minimum supported version of Kotlin to 2.0. If you need to use an older version, compatibility with 1.8.22 is restored in Embrace 7.9.0.
@@ -129,7 +129,7 @@ This release bumped the minimum supported version of Kotlin to 2.0. If you need 
 
 ### 7.7.0
 
-*July 18, 2025*
+_July 18, 2025_
 
 :::info Important
 This release bumped the minimum supported version of Kotlin to 2.0. If you need to use an older version, compatibility with 1.8.22 is restored in Embrace 7.9.0.
@@ -142,7 +142,7 @@ This release bumped the minimum supported version of Kotlin to 2.0. If you need 
 
 ### 7.6.1
 
-*July 17, 2025*
+_July 17, 2025_
 
 :::info Important
 This version is identical to 7.6.0 except that the desugaring requirement if your app supports Android API levels < 26 will be verified at build time.
@@ -154,7 +154,7 @@ This patch is unnecessary if you are already running 7.6.0. But if you support A
 
 ### 7.6.0
 
-*June 25, 2025*
+_June 25, 2025_
 
 :::warning Important
 This version requires desugaring if your app supports Android API levels < 26. For more information, please see [Google's documentation here](https://developer.android.com/studio/write/java8-support#library-desugaring)
@@ -165,7 +165,7 @@ This version requires desugaring if your app supports Android API levels < 26. F
 
 ### 7.5.0
 
-*June 9, 2025*
+_June 9, 2025_
 
 - New configuration option to start the SDK automatically (default off)
 - Link Spans with Sessions in which they ended via Span Links
@@ -174,7 +174,7 @@ This version requires desugaring if your app supports Android API levels < 26. F
 
 ### 7.4.0
 
-*May 5, 2025*
+_May 5, 2025_
 
 - OTel integration improvements
   - API to add custom Resource attributes
@@ -185,7 +185,7 @@ This version requires desugaring if your app supports Android API levels < 26. F
 
 ### 7.3.0
 
-*March 18, 2025*
+_March 18, 2025_
 
 - Improved app startup instrumentation
   - Updated name of root and child spans logged for cold and warm app startups
@@ -200,7 +200,7 @@ This version requires desugaring if your app supports Android API levels < 26. F
 
 ### 7.2.0
 
-*February 27, 2025*
+_February 27, 2025_
 
 - Fixed stacktrace deobfuscation in React Native
 - Fixed build issues on some apps that use DexGuard
@@ -209,7 +209,7 @@ This version requires desugaring if your app supports Android API levels < 26. F
 
 ### 7.1.0
 
-*February 7, 2025*
+_February 7, 2025_
 
 - Fixed stacktrace symbolication issue caused by incorrect ProGuard rules
 - Added API for sending log messages that contain binary attachments
@@ -217,7 +217,7 @@ This version requires desugaring if your app supports Android API levels < 26. F
 
 ### 7.0.0
 
-*January 28, 2025*
+_January 28, 2025_
 
 :::warning Important
 This version has an issue where JVM symbol mapping files are sometimes not being uploaded correctly, leading to some call stacks being partially obfuscated (e.g. in crashes and ANRs). Please use 7.1.0 instead.
@@ -246,7 +246,7 @@ This version has an issue where JVM symbol mapping files are sometimes not being
 
 ### 6.14.0
 
-*October 31, 2024*
+_October 31, 2024_
 
 - Extensive improvements to the resiliency and performance of telemetry persistence and delivery, especially under adverse device and network conditions.
 - Fixed issue where feature flags were not being cached and applied consistently.
@@ -255,7 +255,7 @@ This version has an issue where JVM symbol mapping files are sometimes not being
 
 ### 6.13.0
 
-*September 12, 2024*
+_September 12, 2024_
 
 - Improve SDK startup performance.
 - Fix issue with capturing details of network requests with long URLs.
@@ -263,25 +263,25 @@ This version has an issue where JVM symbol mapping files are sometimes not being
 
 ### 6.12.2
 
-*September 11, 2024*
+_September 11, 2024_
 
 - Fix race condition on app startup when native crash capture is enabled that could result in a crash when the native delegate is accessed before the library is loaded
 
 ### 6.12.1
 
-*September 6, 2024*
+_September 6, 2024_
 
 - Fix JVM crash recording and Embrace API request retries when Embrace enums are obfuscated.
 - Improve delivery retry of sessions ended by a native crash or background process termination.
 
 ### 6.12.0
 
-*September 5, 2024*
+_September 5, 2024_
 
 :::info Important
 This version contains a bug where obfuscating Embrace classes will lead to JVM crashes not being recorded and failed requests to Embrace not being retried after that app process terminates.
 
-*This version should not be used*, but you can workaround this by adding the following keep rule to your Proguard file so R8 will bypass obfuscation for the matched code:
+_This version should not be used_, but you can workaround this by adding the following keep rule to your Proguard file so R8 will bypass obfuscation for the matched code:
 
 `-keep class io.embrace.android.embracesdk.** { *; }`
 :::
@@ -293,7 +293,7 @@ This version contains a bug where obfuscating Embrace classes will lead to JVM c
 
 ### 6.11.0
 
-*August 27, 2024*
+_August 27, 2024_
 
 - Update cached background activities when session properties are modified.
 - Apply configuration defined in `embrace-config.json` properly if appId is not specified (Fix for #1219).
@@ -302,7 +302,7 @@ This version contains a bug where obfuscating Embrace classes will lead to JVM c
 
 ### 6.10.0
 
-*August 13, 2024*
+_August 13, 2024_
 
 - Support Android 15 and devices that use 16KB native page size.
 - Updated minimum requirements to the following:
@@ -319,7 +319,7 @@ This version contains a bug where obfuscating Embrace classes will lead to JVM c
 
 ### 6.9.2
 
-*August 1, 2024*
+_August 1, 2024_
 
 - Fix session recording after app backgrounding if Background Activity is disabled.
 
@@ -331,13 +331,13 @@ Do not use these versions of the SDK. This issue has been addressed in 6.9.2.
 
 ### 6.9.1
 
-*July 10, 2024*
+_July 10, 2024_
 
 - Fix the SDK version sent in session payloads
 
 ### 6.9.0
 
-*July 4, 2024*
+_July 4, 2024_
 
 - OpenTelemetry compatibility improvements:
   - Provide implementation of the [OpenTelemetry Tracing API](https://opentelemetry.io/docs/specs/otel/trace/api/).
@@ -356,25 +356,25 @@ Do not use these versions of the SDK. This issue has been addressed in 6.9.2.
 
 ### 6.8.3
 
-*July 17, 2024*
+_July 17, 2024_
 
 - No change to functionality. Remove error log integration verification explicitly for apps that don't use R8 to strip out unreferenced classes.
 
 ### 6.8.2
 
-*June 7, 2024*
+_June 7, 2024_
 
 - Remove dependency on the configuration attribute `enable_automatic_activity_capture` for manually capturing views
 
 ### 6.8.1
 
-*June 4, 2024*
+_June 4, 2024_
 
 - Fix a build error while reading the `api_token` from an environment variable.
 
 ### 6.8.0
 
-*May 28, 2024*
+_May 28, 2024_
 
 - Complete migration to OpenTelemetry, which means all app data recorded by the SDK can be sent directly to OpenTelemetry Collectors from the app.
 - Allow the SDK to be used without being an Embrace customer, so data is only sent to OpenTelemetry Collectors and not to Embrace.
@@ -384,13 +384,13 @@ Do not use these versions of the SDK. This issue has been addressed in 6.9.2.
 
 ### 6.7.0
 
-*April 22, 2024*
+_April 22, 2024_
 
 - Support configuration of OpenTelemetry Exporters to export [Logs](/android/integration-advanced/log-message-api/#export-your-telemetry) data as OpenTelemetry LogRecord.
 
 ### 6.6.0
 
-*April 19, 2024*
+_April 19, 2024_
 
 :::info Important
 API Desugaring is now a requirement for apps that support Android 5 and 6. This is a simple, well-supported process done by Android build tooling that backports certain Java 8 language features onto older Android versions that didn't have support. For more information, please see [Google's documentation here](https://developer.android.com/studio/write/java8-support#library-desugaring)
@@ -402,17 +402,19 @@ API Desugaring is now a requirement for apps that support Android 5 and 6. This 
 
 ### 6.5.0
 
-*March 14, 2024*
+_March 14, 2024_
 :::info Important
 
 - Increase our minimum Gradle version to 6.5.1
+
 :::
+
 - Fully support configuration cache on all Gradle versions.
 - Fix issue with active Moments being lost when a new session starts.
 
 ### 6.4.0
 
-*March 6, 2024*
+_March 6, 2024_
 
 - Traces improvements
   - Support configuration of OpenTelemetry Exporters to export [Traces](/android/features/traces/#export-to-opentelemetry-collectors) data as OpenTelemetry Spans (beta).
@@ -433,14 +435,14 @@ API Desugaring is now a requirement for apps that support Android 5 and 6. This 
 
 ### 6.3.2
 
-*February 23, 2024*
+_February 23, 2024_
 
 - Improved performance and stability of NDK serialization while the app is under memory pressure
 - Added back support of OkHttp 3.13.0+, which was initially removed in this major version
 
 ### 6.3.1
 
-*February 2, 2024*
+_February 2, 2024_
 
 :::info Important
 The [Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html) feature for Gradle 8.4+ is not compatible with this release due to an [issue in Gradle tooling](https://github.com/gradle/gradle/issues/19252). Please disable this in developer builds when used with this release or use an older version of Gradle.
@@ -451,7 +453,7 @@ The [Configuration Cache](https://docs.gradle.org/current/userguide/configuratio
 
 ### 6.3.0
 
-*January 31, 2024*
+_January 31, 2024_
 
 :::info Important
 Gradle 8.4+ is not supported by this version when the NDK crash capture feature is off. Please use 6.3.1 to ensure all expected Gradle versions are supported.
@@ -470,7 +472,7 @@ Gradle 8.4+ is not supported by this version when the NDK crash capture feature 
 
 ### 6.2.0
 
-*December 13, 2023*
+_December 13, 2023_
 
 - Removed the capture of unused beta features: strict mode violation, activity lifecycle,
 - Improved the delivery of session messages with changes in the DeliveryService class
@@ -481,7 +483,7 @@ Gradle 8.4+ is not supported by this version when the NDK crash capture feature 
 
 ### 6.1.0
 
-*November 24, 2023*
+_November 24, 2023_
 
 - Enabled [Traces](/android/features/traces/) by default
 - Improved build performance of the Gradle plugin
@@ -491,7 +493,7 @@ Gradle 8.4+ is not supported by this version when the NDK crash capture feature 
 
 ### 6.0.0
 
-*October 26, 2023*
+_October 26, 2023_
 
 - Removal of deprecated methods
   - Check our [upgrading guide](/android/upgrading/)
@@ -506,13 +508,13 @@ We strongly recommend that Embrace customers ensure their apps meet the criteria
 
 ### 5.25.1
 
-*December 7, 2023*
+_December 7, 2023_
 
 - Fixed a validation issue when calling deprecated method logNetworkRequest.
 
 ### 5.25.0
 
-*October 10, 2023*
+_October 10, 2023_
 
 - Added support for tap tracking on Jetpack Compose elements.
 - Added support for the Network Span Forwarding feature that enables the propagation of a W3C-compliant traceheader in requests to Embrace so a span can be created and forwarded to the customer servers.
@@ -523,7 +525,7 @@ We strongly recommend that Embrace customers ensure their apps meet the criteria
 
 ### 5.24.0
 
-*September 21, 2023*
+_September 21, 2023_
 
 - Renamed several API interfaces to standardize naming between our SDKs to better reflect what each API does.
 - Added new API method to get the current session ID.
@@ -533,7 +535,7 @@ We strongly recommend that Embrace customers ensure their apps meet the criteria
 
 ### 5.23.0
 
-*August 09, 2023*
+_August 09, 2023_
 
 - Bug fix on retryLock function. Now the ANR monitoring is Serialized to work on a single background executor.
 - Fixed missing Unity ANR
@@ -543,7 +545,7 @@ We strongly recommend that Embrace customers ensure their apps meet the criteria
 
 ### 5.22.0
 
-*July 12, 2023*
+_July 12, 2023_
 
 - Implemented CPU and EGL device information for devices with NDK enabled.
 - Fixed a bug that caused coordinates on Jetpack Compose view to be incorrectly set at 0,0.
@@ -551,7 +553,7 @@ We strongly recommend that Embrace customers ensure their apps meet the criteria
 
 ### 5.21.0
 
-*June 27, 2023*
+_June 27, 2023_
 
 - Added the method getLastRunEndState() to check whether the last execution crashed or was a clean exit.
 - Fixed a duplicate resources error that failed the build in some scenarios.
@@ -559,7 +561,7 @@ We strongly recommend that Embrace customers ensure their apps meet the criteria
 
 ### 5.20.0
 
-*June 16, 2023*
+_June 16, 2023_
 
 - Fixed false positive ANR
 - Improvements in AppExitInfo capture logic
@@ -569,59 +571,59 @@ We strongly recommend that Embrace customers ensure their apps meet the criteria
 
 ### 5.19.0
 
-*May 24, 2023*
+_May 24, 2023_
 
 - Added support for Gradle 8
 
 ### 5.18.2
 
-*May 11, 2023*
+_May 11, 2023_
 
 - Fixed a build time error related to `disableDependencyInjection` property.
 
 ### 5.18.1
 
-*May 5, 2023*
+_May 5, 2023_
 
 - Fixed a build time error at build time for versions `5.17.1` and `5.18.0` in some specific scenarios and related with `com.squareup.okhttp3:okhttp` and `com.android.volley:volley` dependencies.
 
 ### 5.18.0
 
-*May 4, 2023*
+_May 4, 2023_
 
 - Core Web vitals capture from web views.
 - The encoding for extracted file names is enabled for builds that use Android Gradle Plugin 4.2.1 and below. This handles build issues caused by 3rd party plugins that minify classes during the build phase.
 
 ### 5.17.1
 
-*Apr 27, 2023*
+_Apr 27, 2023_
 
 - Upgrade compileSDK to 33.
 - Improvements on our CPU usage and data consumption of our delivery layer.
 
 ### 5.16.0
 
-*Apr 04, 2023*
+_Apr 04, 2023_
 
 - Added the name and message of the Exception if it is used on logError or logHandledException methods.
 - Deprecated the current logPushNotification method and introduced a new one that fix compatibility issues.
 
 ### 5.15.2
 
-*Mar 21, 2023*
+_Mar 21, 2023_
 
 - Fix an error from `5.15.1` around identifying users.
 - Improvements in how data is collected after session ends, to avoid extending the app process duration.
 
 ### 5.15.1
 
-*Mar 17, 2023*
+_Mar 17, 2023_
 
 - Improvements in how data is collected after session ends, to avoid extending the app process duration.
 
 ### 5.14.2
 
-*Mar 7, 2023*
+_Mar 7, 2023_
 :::info Important
 This version has a known issue with Braze. If you need to use this specific version, you can avoid the known issue with the following configuration in your `app/build.gradle` file:
 
@@ -639,21 +641,21 @@ swazzler {
 
 ### 5.13.0
 
-*Jan 27, 2023*
+_Jan 27, 2023_
 
 - Reduced ANRs being generated by EmbraceLogger class.
 - Added feature to capture network body information.
 
 ### 5.12.0
 
-*Jan 19, 2023*
+_Jan 19, 2023_
 
 - Fixed an issue on ndk symbols.
 - Fixed an ndk issue when building.
 
 ### 5.11.0
 
-*Jan 11, 2023*
+_Jan 11, 2023_
 
 - Capture CPU number of cores
 - Compress Proguard/R8 mapping files before uploading
@@ -661,7 +663,7 @@ swazzler {
 
 ### 5.10.0
 
-*Dec 07, 2022*
+_Dec 07, 2022_
 
 - Automatically capture push notifications when the app is on foreground.
 - Added the ability to manually log push notifications.
@@ -670,19 +672,19 @@ swazzler {
 
 ### 5.9.4
 
-*Dec 05, 2022*
+_Dec 05, 2022_
 
 - Added the ability to report the version of the Embrace React Native SDK being used.
 
 ### 5.9.3
 
-*Nov 20, 2022*
+_Nov 20, 2022_
 
 - It fixes a Gradle issue on anyone running Gradle < 6.2
 
 ### 5.9.2
 
-*Nov 28, 2022*
+_Nov 28, 2022_
 :::info Important
 This version has a known issue with Gradle < 6.2
 :::
@@ -691,13 +693,13 @@ This version has a known issue with Gradle < 6.2
 
 ### 5.9.1
 
-*Nov 14, 2022*
+_Nov 14, 2022_
 
 - Fixed an internal exception when trying to access the jailbroken status of the device.
 
 ### 5.9.0
 
-*Nov 03, 2022*
+_Nov 03, 2022_
 
 - Improve NDK service logs to work with strict and integration mode
 - Improved the EmbraceSamples.verify() method
@@ -705,7 +707,7 @@ This version has a known issue with Gradle < 6.2
 
 ### 5.8.0
 
-*Oct 20, 2022*
+_Oct 20, 2022_
 
 - Fixed message for Ironsource and Moshi known issues.
 - Automate disabling dependency injection when using EDM4U.
@@ -715,26 +717,26 @@ This version has a known issue with Gradle < 6.2
 
 ### 5.7.1
 
-*Oct 18, 2022*
+_Oct 18, 2022_
 
 - Fixed an ANR occurring in React Native projects using a custom JavaScript bundle URL.
 
 ### 5.7.0
 
-*Oct 03, 2022*
+_Oct 03, 2022_
 
 - New mechanism to auto-install Embrace dependencies. If you prefer to use the old mechanism, the new API can be disabled by setting the `useNewDependencyInstaller` property to false.
 
 ### 5.6.2
 
-*Oct 03, 2022*
+_Oct 03, 2022_
 
 - Fixed a lost backward compatibility with previous Unity SDK versions.
 - Fixed internal exception triggered when used androidX startup library in Unity builds.
 
 ### 5.6.1
 
-*Sep 22, 2022*
+_Sep 22, 2022_
 
 :::info Important
 This version has a known backward compatibility issue between the Unity SDK and the Android SDK
@@ -744,7 +746,7 @@ This version has a known backward compatibility issue between the Unity SDK and 
 
 ### 5.6.0
 
-*Sep 20, 2022*
+_Sep 20, 2022_
 
 - Prevent disk i/o strict mode violations for session caching.
 - Added a step to the automatic verification that validates that the SDK is receiving lifecycle events
@@ -752,20 +754,20 @@ This version has a known backward compatibility issue between the Unity SDK and 
 
 ### 5.5.4
 
-*Aug 30, 2022*
+_Aug 30, 2022_
 
 - Performance improvement: moved some disk I/O operations on startup to a worker thread.
 
 ### 5.5.3
 
-*Aug 25, 2022*
+_Aug 25, 2022_
 
 - Fixed a logic bug in how the previous signal handler was called that prevented native tombstones from being captured by the Android OS.
 - Fixed an issue that prevented the Swazzler to build on AGP versions greater or equal than 7.2.
 
 ### 5.5.2
 
-*Aug 17, 2022*
+_Aug 17, 2022_
 
 - Fixes a bug in our gradle plugin where the build sometimes failed with duplicate resource files
 - Fixes a minor bug where network intercepting triggers a log when it tries to intercept calls before Embrace is started.
@@ -773,13 +775,13 @@ This version has a known backward compatibility issue between the Unity SDK and 
 
 ### 5.5.1
 
-*Aug 03, 2022*
+_Aug 03, 2022_
 
 - Fixes an issue where customers were having ClassNotFoundException: BuildEventsListenerRegistry for gradle versions < 6.1
 
 ### 5.5.0
 
-*Aug 02, 2022*
+_Aug 02, 2022_
 
 :::warning Important
 This version has a known issue with Gradle < 6.1
@@ -791,7 +793,7 @@ This version has a known issue with Gradle < 6.1
 
 ### 5.4.0
 
-*Jul 18, 2022*
+_Jul 18, 2022_
 
 :::warning Important
 This version has a known issue with Gradle < 6.1
@@ -803,7 +805,7 @@ This version has a known issue with Gradle < 6.1
 
 ### 5.3.0
 
-*Jun 30, 2022*
+_Jun 30, 2022_
 
 :::warning Important
 This version has a known issue with Gradle < 6.1
@@ -813,7 +815,7 @@ This version has a known issue with Gradle < 6.1
 
 ### 5.2.0
 
-*Jun 10, 2022*
+_Jun 10, 2022_
 
 - Added support for symbols upload in Unity 2020, 2021, 2022.
 - Fixed symbols upload failure while searching .so files in a folder with another folder inside.
@@ -823,7 +825,7 @@ This version has a known issue with Gradle < 6.1
 
 ### 5.1.0
 
-*May 27, 2022*
+_May 27, 2022_
 
 - Added extra logging for NDK crash.
 - Prevented NPE in native crash loading.
@@ -832,25 +834,25 @@ This version has a known issue with Gradle < 6.1
 
 ### 5.0.4
 
-*May 4, 2022*
+_May 4, 2022_
 
 - Fixed an issue where "Bytes in" and "Bytes out" were shown reversed when logging network requests manually.
 
 ### 5.0.3
 
-*May 2, 2022*
+_May 2, 2022_
 
 - Fixed a race condition that could lead to exceptions during SDK initialization.
 
 ### 5.0.2
 
-*April 22, 2022*
+_April 22, 2022_
 
 - Fixed an issue that prevented the SDK to use the traffic settings override for specific app versions.
 
 ### 5.0.1
 
-*April 08, 2022*
+_April 08, 2022_
 
 - Added backward compatibility up to AGP 3.4.0
 - Changed build ID resource injection to keep unchanged on non-minified builds.
@@ -860,7 +862,7 @@ This version has a known issue with Gradle < 6.1
 
 ### 4.15.0
 
-*Feb 07, 2022*
+_Feb 07, 2022_
 
 - Updated Kotlin to 1.4.32
 - Fixed stacktrace capture for React Native and Unity log messages
@@ -869,20 +871,20 @@ This version has a known issue with Gradle < 6.1
 
 ### 4.14.0
 
-*Dec 21, 2021*
+_Dec 21, 2021_
 
 - Screenshots aren't captured by default. They should be manually requested by calling the proper methods of the SDK.
 
 ### 4.13.0
 
-*Nov 19, 2021*
+_Nov 19, 2021_
 
 - Upgrade Gson to 2.8.9
 - Added a new EmbraceCustomPathException to capture the proper custom path on connectivity errors
 
 ### 4.12.0
 
-*Oct 29, 2021*
+_Oct 29, 2021_
 
 - Added swazzling class skipping support for AGP 4.2+
 - Added swazzling rules generation support for AGP 4.2+
@@ -890,13 +892,13 @@ This version has a known issue with Gradle < 6.1
 
 ### 4.11.3
 
-*Oct 18, 2021*
+_Oct 18, 2021_
 
 - Fix an issue with missing network calls in the session
 
 ### 4.11.2
 
-*Oct 5, 2021*
+_Oct 5, 2021_
 
 - Added option to specify API key as an environment variable instead of in the config file
 - Cache device-related values that could take a long time to fetch on certain device types, to prevent ANRs.
@@ -905,7 +907,7 @@ This version has a known issue with Gradle < 6.1
 
 ### 4.11.0
 
-*Sep 1, 2021*
+_Sep 1, 2021_
 
 :::warning Important
 This version has known issues and should not be used
@@ -917,34 +919,34 @@ This version has known issues and should not be used
 
 ### 4.10.0
 
-*Aug 16, 2021*
+_Aug 16, 2021_
 
 - Added support for custom Unity symbols archive name.
 - Improved handling of JAR files that could not be swazzled.
 
 ### 4.9.3
 
-*July 29, 2021*
+_July 29, 2021_
 
 - Fixed issue that could cause an ANR when capturing memory warnings.
 - Fixed issue that could cause SDK to start during an app cold start even when remote config should have disabled it.
 
 ### 4.9.2
 
-*July 15, 2021*
+_July 15, 2021_
 
 - Fixed compatibility issue with androidx.lifecycle 2.3.0+ when not starting the SDK on the main thread.
 
 ### 4.9.1
 
-*July 13, 2021*
+_July 13, 2021_
 
 - Fixed issue that could prevent capture of OkHTTP- and Volley-based network calls for certain configurations.
 - Prevent multiple attempts to add Embrace SDK dependency for certain configurations.
 
 ### 4.9.0
 
-*July 1, 2021*
+_July 1, 2021_
 
 - Fixed how SDK dependencies are injected, which could cause build errors for certain Gradle configurations.
 - Handle case where a project provides the same JAR twice to Gradle our Gradle transformer.
@@ -952,66 +954,66 @@ This version has known issues and should not be used
 
 ### 4.8.10
 
-*May 27, 2021*
+_May 27, 2021_
 
 - Fixed issue with NDK crash stack trace parsing that could fail for certain stack traces.
 - Track JNI thread attachment for Unity.
 
 ### 4.8.9
 
-*May 25, 2021*
+_May 25, 2021_
 
 - Removed all dependencies on JCenter.
 - Added support for symbol upload for Unity 2020 non-exported apps.
 
 ### 4.8.8
 
-*May 17, 2021*
+_May 17, 2021_
 
 - Fixed an issue with registering build tasks for React Native apps.
 
 ### 4.8.7
 
-*May 11, 2021*
+_May 11, 2021_
 
 - Fixed an issue where HTTP network calls made using the Java library could get disrupted during capture. This issue did not affect HTTPS calls or those made with Volley or OkHttp.
 
 ### 4.8.6
 
-*May 10, 2021*
+_May 10, 2021_
 
 - Fixed a compatibility issue with gradle 7.x.
 - Added support for automatic upload of NDK symbols for unexported Unity projects.
 
 ### 4.8.5
 
-*May 6, 2021*
+_May 6, 2021_
 
 - Fixed issue with bytes-in/-out values for manually recorded network calls on Unity.
 - Added exception message to manually-recorded network calls on Unity for network calls that had an error.
 
 ### 4.8.4
 
-*May 4, 2021*
+_May 4, 2021_
 
 - Added more flexible support for disabling swazzling based on variant.
 
 ### 4.8.3
 
-*April 30, 2021*
+_April 30, 2021_
 
 - Added support for Unity unhandled exceptions
 - Fixed issue with the upload of NDK symbols for Unity 2018 and injection of references to the symbols into the SDK
 
 ### 4.8.2
 
-*April 22, 2021*
+_April 22, 2021_
 
 - Moved from JCenter to Maven Central
 
 ### 4.8.0
 
-*April 9, 2021*
+_April 9, 2021_
 
 - Added method to allow overriding of the configured app ID to be overridden at runtime.
 - Modified Gradle plugin to use original JARs when no changes were needed to them. This addresses an issue with the `kotlin-reflect` module for Kotlin 1.4.10 and newer.
@@ -1021,7 +1023,7 @@ This version has known issues and should not be used
 
 ### 4.7.1
 
-*March 18, 2021*
+_March 18, 2021_
 
 - Modified capture_request_content_length setting to also affect requests made with OkHTTP
 - Fixed issue that would remove Content-Length and Content-Encoding from certain captured requests
@@ -1031,7 +1033,7 @@ This version has known issues and should not be used
 
 ### 4.7.0
 
-*February 22, 2021*
+_February 22, 2021_
 
 - Added limits for number of logs per session: 250 error, 100 warning, 100 info (contact support to have these increased for your app).
 - Limit how many breadcrumbs are captured for a session at capture time rather than at the completion of a session. This limits the memory used to store breadcrumbs for a session.
@@ -1041,13 +1043,13 @@ This version has known issues and should not be used
 
 ### 4.6.7
 
-*February 18, 2021*
+_February 18, 2021_
 
 - Reverted relaxed AndroidX version requirements introduced in 4.6.6. since AndroidX 2.3.0+ caused issues.
 
 ### 4.6.6
 
-*February 10, 2021*
+_February 10, 2021_
 
 :::warning Important
 This version has known issues and should not be used
@@ -1057,131 +1059,131 @@ This version has known issues and should not be used
 
 ### 4.6.5
 
-*February 2, 2021*
+_February 2, 2021_
 
 - Improved SDK startup time.
 - Added Gradle task dependencies to support a single flavor anchoring tests for other variants.
 
 ### 4.6.4
 
-*January 22, 2021*
+_January 22, 2021_
 
 - Fixed issue that could cause session message to not be sent when the device had been in airplane mode and NDK crash support is enabled.
 
 ### 4.6.3
 
-*January 14, 2021*
+_January 14, 2021_
 
 - Fixed device ID generation to allow it to be used in automated tests.
 
 ### 4.6.2
 
-*January 12, 2021*
+_January 12, 2021_
 
 - Added configuration setting to disable capture of native network requests.
 
 ### 4.6.1
 
-*January 11, 2021*
+_January 11, 2021_
 
 - Added support for configuration files for product flavors.
 - Fixed bug that could cause a crash when network request size capture was enabled for native requests.
 
 ### 4.6.0
 
-*December 14, 2020*
+_December 14, 2020_
 
 - Added support for Unity applications.
 - Added debug logging mode.
 
 ### 4.5.6
 
-*October 21, 2020*
+_October 21, 2020_
 
 - Fixed dependency resolution issues with AGP 4.1.0+.
 
 ### 4.5.5
 
-*October 1, 2020*
+_October 1, 2020_
 
 - Fixed capture of ANR stacktraces for Android 7 and earlier.
 - Fixed Gradle plugin compatibility with AGP 4.1.0-rc1.
 
 ### 4.5.4
 
-*September 17, 2020*
+_September 17, 2020_
 
 - Added options to disable capture of web views and web view query parameters.
 - Truncate ANR stack traces to 100 lines.
 
 ### 4.5.3
 
-*September 9, 2020*
+_September 9, 2020_
 
 - Fixed issue with setting user identity on clean installs (introduced in 4.5.2)
 
 ### 4.5.2
 
-*Use 4.5.3 since it contains a bugfix for a critical bug introduced in this release*
+_Use 4.5.3 since it contains a bugfix for a critical bug introduced in this release_
 
-*September 2, 2020*
+_September 2, 2020_
 
 - Capture additional metrics
 - Capture user info for NDK crashes
 - Enable ANR stacktrace capture by default for all users
 - Fixed issue with ANR stacktrace capture that could attribute an ANR to the session after it occurred
-- Fixed issue with Proguard/R8 upload that could prevent upload of mapping files for flavors  
+- Fixed issue with Proguard/R8 upload that could prevent upload of mapping files for flavors
 
 ### 4.5.1
 
-*August 10, 2020*
+_August 10, 2020_
 
 - Added build option to disable swazzling of specific classes and/or jars
 - Improved performance of serializing sessions with large numbers of recorded network calls
 
 ### 4.5.0
 
-*July 24, 2020*
+_July 24, 2020_
 
 - Added configuration to disable swazzling for specific build types
-- Fixed bug introduced in 4.4.1 that prevented upload of Proguard files  
+- Fixed bug introduced in 4.4.1 that prevented upload of Proguard files
 
 ### 4.4.1
 
-*July 14, 2020*
+_July 14, 2020_
 
 - Fixed bug where cached sessions were not sent if NDK crash support was not enabled
 - Fixed bug where only the first 3 ANR intervals were captured
 
 ### 4.4.0
 
-*July 2, 2020*
+_July 2, 2020_
 
 - Added NDK crash reporting
 
 ### 4.2.10
 
-*June 18, 2020*
+_June 18, 2020_
 
 - Fixed a concurrency bug that could trigger when making network calls shortly after startup
 - Added nullability annotations to improve Kotlin integration experience
 
 ### 4.2.9
 
-*May 26, 2020*
+_May 26, 2020_
 
 - Fixed an issue with capturing network request and response sizes for gzipped native requests when the content type header was lowercase.
 
 ### 4.2.8
 
-*May 15, 2020*
+_May 15, 2020_
 
 - Added option to disable capture of app disk usage. This could be excessively slow on older devices with large numbers of files in the app directory.
 - Disabled capturing network request and response sizes for native requests by default.
 
 ### 4.2.7
 
-*April 27, 2020*
+_April 27, 2020_
 
 - Migrated to AndroidX
 - Fixed issue with Proguard/R8 uploads with AGP 3.6.x
@@ -1191,14 +1193,14 @@ This version has known issues and should not be used
 
 ### 4.2.5
 
-*April 15, 2020*
+_April 15, 2020_
 
 - New config property `sessions.disabled_url_patterns` filters network requests entirely from session.
 - Added more logging around which embrace-config.json file is used and which paths were scanned.
 
 ### 4.2.4
 
-*April 8, 2020*
+_April 8, 2020_
 
 - Added option to send session end message asynchronously
 - Only check the app's disk usage once during a session. This operation could take too long on certain devices for apps with large numbers of files to be done repeatedly
@@ -1206,7 +1208,7 @@ This version has known issues and should not be used
 
 ### 4.2.2
 
-*March 31, 2020*
+_March 31, 2020_
 
 - Fixed bug where temporary session properties would only be cleared on cold start. Now they are cleared at the end of each session
 - Show all custom configuration settings in the console log at startup
@@ -1215,13 +1217,13 @@ This version has known issues and should not be used
 
 ### 4.2.1
 
-*March 12, 2020*
+_March 12, 2020_
 
 - Fixed issue that prevented removal of session properties
 
 ### 4.2.0
 
-*March 11, 2020*
+_March 11, 2020_
 
 - Added ability to add properties to sessions
 - Capture additional thread info at the time of a crash
@@ -1230,7 +1232,7 @@ This version has known issues and should not be used
 
 ### 4.1.0
 
-*March 3, 2020*
+_March 3, 2020_
 
 - Added support to capture fragments manually
 - Removed incorrect build-time logs that referenced the usage of deprecated features
@@ -1238,13 +1240,13 @@ This version has known issues and should not be used
 
 ### 4.0.1
 
-*January 16, 2020*
+_January 16, 2020_
 
 - Fixed bug in Embrace Gradle plugin that could lead to SDK config not being properly read when building an app bundle
 
 ### 4.0.0
 
-*January 14, 2020*
+_January 14, 2020_
 
 - Added a more flexible configuration approach that simplifies how custom configurations can be set up for different build variants
 - Added user info association that is set during a session even if it was cleared before the session ended
@@ -1256,19 +1258,19 @@ This version has known issues and should not be used
 
 ### 3.7.2
 
-*November 7, 2019*
+_November 7, 2019_
 
 - Added a config setting to allow disabling of gunzipping of requests made with the native Android network request framework. By default the SDK handles the gunzipping to allow response size to be computed, but this can interfere with certain services.
 
 ### 3.7.1
 
-*October 22, 2019*
+_October 22, 2019_
 
 - Improves capture of React Native crashes.
 
 ### 3.7.0
 
-*October 21, 2019*
+_October 21, 2019_
 
 - Added option to disable capture of tap coordinates.
 - Added support for React Native crashes.
@@ -1278,19 +1280,19 @@ This version has known issues and should not be used
 
 ### 3.6.2
 
-*September 8, 2019*
+_September 8, 2019_
 
 - Fixed issue that prevented uploading of mapping info when using r8
 
 ### 3.6.1
 
-*September 13, 2019*
+_September 13, 2019_
 
 - Added option to allow startup screenshots to be disabled
 
 ### 3.6.0
 
-*September 10, 2019*
+_September 10, 2019_
 
 - Removed network requests made when setting user info
 - Fixed bug that could cause an exception when using other SDKs that monitor network traffic
@@ -1298,14 +1300,14 @@ This version has known issues and should not be used
 
 ### 3.5.1
 
-*August 12, 2019*
+_August 12, 2019_
 
 - Handles attempt to set trace ID before SDK initialization
 - Re-added removed `logNetworkCall` and `logNetworkClientError` methods
 
 ### 3.5.0
 
-*August 9, 2019*
+_August 9, 2019_
 
 - We added support for passing a Throwable to logError. If you pass a Throwable, the stack trace from the Throwable will be used instead of the stack trace from where the logError method was called.
 - Log messages are now limited to 128 characters. Contact us if you need longer log messages.
@@ -1320,12 +1322,12 @@ This version has known issues and should not be used
 
 ### 3.4.1
 
-*July 22, 2019*
+_July 22, 2019_
 
 - Fixed typos in methods to set bytes in and out for manually-captured requests
 
 ### 3.4.0
 
-*July 22, 2019*
+_July 22, 2019_
 
 - Added support for manual capture of network requests. The SDK is capable of automatically capturing the majority of REST network calls made by applications, but this new method allows recording of network requests that are not automatically captured, such as gRPC requests.

--- a/docs/android/faq.md
+++ b/docs/android/faq.md
@@ -238,17 +238,17 @@ This could be due to one of the following reasons:
   - PacketZoom
 - If you are using `OkHttp3`, make sure to get an instance of `OkHttpClient` by calling the builder:
 
-    ```kotlin
-        val myOkHttpClient = OkHttpClient.Builder().build()
-    ```
+  ```kotlin
+      val myOkHttpClient = OkHttpClient.Builder().build()
+  ```
 
-    instead of getting a new instance by calling the constructor:
+  instead of getting a new instance by calling the constructor:
 
-    ```kotlin
-        val myOkHttpClient = OkHttpClient()
-    ```
+  ```kotlin
+      val myOkHttpClient = OkHttpClient()
+  ```
 
-    The SDK instruments the `build()` method, so it will only track network requests with the first approach.
+  The SDK instruments the `build()` method, so it will only track network requests with the first approach.
 
 #### **What does Embrace use to hook into network calls on Android apps?**
 

--- a/docs/android/features/identify-users.md
+++ b/docs/android/features/identify-users.md
@@ -27,7 +27,7 @@ We recommend using an anonymized or hashed user ID that only your agents can sea
 :::
 
 The above call annotates the session with a user identifier that you can use later to search for this user.
-For more methods on setting user values, see the [API docs](/api/android/).  
+For more methods on setting user values, see the [API docs](/api/android/).
 
 You can also set customized values for specific use cases or segments of users.
 

--- a/docs/android/features/jetpack-compose.md
+++ b/docs/android/features/jetpack-compose.md
@@ -24,11 +24,11 @@ To enable onClick instrumentation, you will need to modify your `embrace-config.
 
 ```json
 {
-    "sdk_config": {
-        "compose": {
-            "capture_compose_onclick": true
-        }
+  "sdk_config": {
+    "compose": {
+      "capture_compose_onclick": true
     }
+  }
 }
 ```
 
@@ -86,7 +86,7 @@ Row(
 ){ ... }
 ```
 
-Clickable element that already defines the onClick action under the hood.  
+Clickable element that already defines the onClick action under the hood.
 
 The following example shows how to add a modifier onClick to override the label but not the actual action, so for the action, it passes null:
 

--- a/docs/android/features/last-run-end-state.md
+++ b/docs/android/features/last-run-end-state.md
@@ -8,7 +8,7 @@ sidebar_position: 10
 
 This API enables customers to automatically/programmatically understand if the previous app instance ended in a crash. Depending on your use case, having the ability to query an API to understand if the previous app instance ended in a crash will enable you to adjust the behavior or UI of your app after a crash has occurred.
 
-**What does previous app instance mean?**  
+**What does previous app instance mean?**
 
 A cold launch, basically. If the app gets backgrounded/resumed so a new session starts, the value returned will not change. So:
 
@@ -40,6 +40,7 @@ val didLastRunCrash = Embrace.lastRunEndState == LastRunEndState.CRASH
 
 - The API can only be called after the SDK has been started. If a call is made prior to starting the Embrace SDK you will get a response of `LastRunEndState.INVALID`
 - It will return that a crash occurred if the app crashed any time since the app last came to the foreground. This includes if the app crashed while running in the background.
+
 :::
 
 #### Version

--- a/docs/android/features/network-body-capture.md
+++ b/docs/android/features/network-body-capture.md
@@ -6,7 +6,7 @@ sidebar_position: 14
 
 ## Network body capture
 
-Embrace's SDK uploads basic information about network requests into your sessions to help you understand and troubleshoot networking problems. Embrace can also capture the network body, including the request, response and any headers.  
+Embrace's SDK uploads basic information about network requests into your sessions to help you understand and troubleshoot networking problems. Embrace can also capture the network body, including the request, response and any headers.
 
 This feature can only be enabled by your Embrace CS representative, so reach out to them on Slack or create a network body capture request by using the button in the dash. Once configured, your requests will be uploaded to Embrace's servers and delivered to you. Make sure you have the following property set as `true` in your `embrace-config.json` file:
 
@@ -24,7 +24,7 @@ This feature can only be enabled by your Embrace CS representative, so reach out
 
 You can check the [configuration file documentation](/android/configuration/configuration-file) for more information.
 
-If your application handles sensitive or private data of any kind, you can protect that data by encrypting the network body capture payloads that are uploaded.  
+If your application handles sensitive or private data of any kind, you can protect that data by encrypting the network body capture payloads that are uploaded.
 
 In your `embrace-config.json` file, first create a new property entry titled:
 
@@ -36,10 +36,10 @@ In your `embrace-config.json` file, first create a new property entry titled:
     },
     "capture_public_key": "[Your Public Key]"
   }
-  ... 
+  ...
 ```
 
-RSA encryption uses two keys: a private and a public key. You may already be familiar with this protocol and the security team in your organization may already have public keys available for you to use. Before generating new keys, check with your organization.  
+RSA encryption uses two keys: a private and a public key. You may already be familiar with this protocol and the security team in your organization may already have public keys available for you to use. Before generating new keys, check with your organization.
 
 There are many ways to generate working key pairs. For these instructions, use the CLI openssl tool installed by default on most linux-like systems using a size key of 2048:
 

--- a/docs/android/features/performance-instrumentation.md
+++ b/docs/android/features/performance-instrumentation.md
@@ -46,7 +46,7 @@ Note: Be mindful of when these customization methods are invoked. They will only
 
 If you want something other than an Activity rendering to end a startup trace, you can configure the SDK so that it waits for the app to manually end it.
 
-To do that, first set the configuration property `end_startup_with_app_ready` in `embrace-config.json` in the section `sdk_config.automatic_data_capture` to `true`. Then, in your app code, call the method `appReady()` when you wish to signal that app startup has ended successfully.  
+To do that, first set the configuration property `end_startup_with_app_ready` in `embrace-config.json` in the section `sdk_config.automatic_data_capture` to `true`. Then, in your app code, call the method `appReady()` when you wish to signal that app startup has ended successfully.
 
 :::tip Synchronize with Android metrics
 If you want to synchronize the app startup traces with the `Time to Full Display` metric provided by Android, see [this section](#mapping-to-android-startup-metrics).
@@ -160,7 +160,7 @@ class SampleApplication(private val nativeLibName: String) : Application() {
                 events = listOf(),
                 errorCode = ErrorCode.FAILURE
             )
-        }    
+        }
         Embrace.applicationInitEnd()
     }
 }

--- a/docs/android/features/push-notifications.md
+++ b/docs/android/features/push-notifications.md
@@ -32,7 +32,7 @@ If you want to capture data from inside the notifications then you can set the c
 
 ### Usage
 
-If your configuration is correct, you don't need to do anything else, you are already capturing notifications automatically. They will appear in your dashboard within the user session timeline.  
+If your configuration is correct, you don't need to do anything else, you are already capturing notifications automatically. They will appear in your dashboard within the user session timeline.
 
 If you don't want the notifications to get captured automatically, then you can avoid the setup from the previous section and when you receive a notification in your code, make the following call manually:
 

--- a/docs/android/features/traces.md
+++ b/docs/android/features/traces.md
@@ -35,7 +35,7 @@ The Embrace Traces API allows you to:
 #### Limits
 
 | Type                                    | Limit           |
-|-----------------------------------------|-----------------|
+| --------------------------------------- | --------------- |
 | Max number of spans started per session | 500             |
 | Max number of attributes per span       | 100             |
 | Max number of events per span           | 10              |
@@ -77,7 +77,7 @@ val activityLoad = Embrace.createSpan("load-activity")
 #### Create and start span atomically
 
 ```kotlin
-// activityLoad will either be a span that has already started or null if 
+// activityLoad will either be a span that has already started or null if
 // the creation or start attempt was unsuccessful
 val activityLoad = Embrace.startSpan("load-activity")
 ```
@@ -100,7 +100,7 @@ Spans created with `recordSpan` or `recordCompletedSpan` will stop once the func
 val appStartTimeMillis = getAppStartTime()
 val appLaunchSpan = Embrace.createSpan("app-launch")
 
-// begin recording a span that has a different start time than 
+// begin recording a span that has a different start time than
 // the current time by starting its root span with a specific timestamp
 appLaunchSpan?.start(startTimeMs = appStartTimeMillis)
 ```
@@ -177,8 +177,8 @@ val imageLoad = activityLoad?.apply { Embrace.startSpan("load-image", this) }
 ```kotlin
 // record a span based on start and end times that are in the past
 Embrace.recordCompletedSpan(
-    name = "activity-create", 
-    startTimeMs = startTimeMillis, 
+    name = "activity-create",
+    startTimeMs = startTimeMillis,
     endTimeMs = endTimeMillis
 )
 ```
@@ -196,7 +196,7 @@ Embrace.getSpan(activityLoadSpanId)?.stop()
 
 ### Export to OpenTelemetry collectors
 
-Telemetry collected by the Embrace SDK can be exported as [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/) through the [SpanExporter](https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-exporter) and [LogRecordExporter](https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordexporter) interfaces. Multiple exporters can be configured, and they will receive telemetry synchronously and serially as soon as they are recorded.  
+Telemetry collected by the Embrace SDK can be exported as [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/) through the [SpanExporter](https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-exporter) and [LogRecordExporter](https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordexporter) interfaces. Multiple exporters can be configured, and they will receive telemetry synchronously and serially as soon as they are recorded.
 
 While more than one exporter for each signal can be configured, be aware of the performance impact on the instrumentation of each additional exporter given that they run serially and will block the instrumentation thread.
 
@@ -208,12 +208,12 @@ Embrace.addLogRecordExporter(myLogExporter)
 ```
 
 :::info
-Note that exporters must be configured *before* the Embrace SDK is started. Exporters added after the SDK has already been started will not be used.
+Note that exporters must be configured _before_ the Embrace SDK is started. Exporters added after the SDK has already been started will not be used.
 :::
 
 #### Supply custom OpenTelemetry processors
 
-It's also possible to supply your own OpenTelemetry processors through the [SpanProcessor](https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-processor) and [LogRecordProcessor](https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordprocessor) interfaces. These will be invoked *after* Embrace's internal processors. Overriding embrace-specific attributes when processing telemetry will produce undefined behavior and is discouraged.
+It's also possible to supply your own OpenTelemetry processors through the [SpanProcessor](https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-processor) and [LogRecordProcessor](https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordprocessor) interfaces. These will be invoked _after_ Embrace's internal processors. Overriding embrace-specific attributes when processing telemetry will produce undefined behavior and is discouraged.
 
 ```kotlin
 Embrace.addSpanProcessor(mySpanProcessor)
@@ -221,7 +221,7 @@ Embrace.addLogRecordProcessor(myLogProcessor)
 ```
 
 :::info
-Processors must be configured *before* the Embrace SDK is started. Processors added after the SDK has already been started will not be used.
+Processors must be configured _before_ the Embrace SDK is started. Processors added after the SDK has already been started will not be used.
 :::
 
 #### Local testing

--- a/docs/android/integration-advanced/crash-reporting.md
+++ b/docs/android/integration-advanced/crash-reporting.md
@@ -28,7 +28,7 @@ Setting [`crash_handler.enabled`](/android/configuration/configuration-file/#cra
 ### NDK crash capture
 
 The Embrace SDK automatically captures NDK crash reports. To disable NDK crash reports add the
- `ndk_enabled` setting to your `app/src/main/embrace-config.json` file:
+`ndk_enabled` setting to your `app/src/main/embrace-config.json` file:
 
 ```json
 {

--- a/docs/android/integration/index.md
+++ b/docs/android/integration/index.md
@@ -161,7 +161,7 @@ implementation 'io.embrace:embrace-android-sdk:{{ embrace_sdk_version platform="
 A JSON-formatted file is used to configure Embrace SDK features. To start off, create a new empty JSON file at `app/src/main/embrace-config.json`:
 
 ```json
-{ }
+{}
 ```
 
 ## Set your app ID and API token

--- a/docs/android/legacy-integration/log-message-api.md
+++ b/docs/android/legacy-integration/log-message-api.md
@@ -124,7 +124,7 @@ Embrace.getInstance().addLogRecordExporter(SystemOutLogRecordExporter.create())
 Embrace.getInstance().addLogRecordExporter(customDockerLogRecordExporter)
 Embrace.getInstance().addLogRecordExporter(grafanaCloudLogRecordExporter)
 
-Embrace.getInstance().start(this)        
+Embrace.getInstance().start(this)
 ```
 
 ### Best Practices

--- a/docs/android/legacy-integration/next-steps.md
+++ b/docs/android/legacy-integration/next-steps.md
@@ -8,7 +8,7 @@ sidebar_position: 8
 
 ### Wrapping Up
 
-Congratulations on completing the Android integration guide!  
+Congratulations on completing the Android integration guide!
 
 If you found anything confusing or have suggestions on improving the docs,
 please don't hesitate to reach out to us at [support@embrace.io](mailto:support@embrace.io) or on Slack.

--- a/docs/android/upgrading.md
+++ b/docs/android/upgrading.md
@@ -61,7 +61,7 @@ If you wish to do the upgrade using step-by-step instructions that will work for
 The Embrace Android SDK supports the following minimum versions of dependent technologies at build and run time:
 
 | Technology                       | Old minimum version | New minimum version |
-|----------------------------------|---------------------|---------------------|
+| -------------------------------- | ------------------- | ------------------- |
 | JDK (Build-time)                 | 11                  | 17                  |
 | Kotlin (Run-time and build-time) | 1.8.22              | 2.0.21              |
 | Gradle (minSdk 26+)              | 7.5.1               | 8.0.2               |
@@ -75,7 +75,7 @@ Gradle 8.4 and AGP 8.3.0 to workaround a desugaring issue.
 The Embrace Android SDK is compiled using the following language compatibility targets:
 
 | Technology                | Old target | New target |
-|---------------------------|------------|------------|
+| ------------------------- | ---------- | ---------- |
 | Java                      | 1.8        | 11         |
 | Kotlin (Language and API) | 1.8        | 2.0        |
 
@@ -84,7 +84,7 @@ The Embrace Android SDK is compiled using the following language compatibility t
 The Embrace Gradle Plugin artifact and plugin ID have been renamed:
 
 | Type        | Old name                      | New name                           |
-|-------------|-------------------------------|------------------------------------|
+| ----------- | ----------------------------- | ---------------------------------- |
 | Artifact ID | `io.embrace:embrace-swazzler` | `io.embrace:embrace-gradle-plugin` |
 | Plugin ID   | `io.embrace.swazzler`         | `io.embrace.gradle`                |
 
@@ -186,23 +186,23 @@ get in touch if you do have a use-case that is no longer met.
 
 ##### Embrace Android SDK removed APIs
 
-| Old API                                                                 | New API                                                                                                |
-|-------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
-| `Embrace.getInstance().start(Context, AppFramework)`                    | `Embrace.start(Context)` and supply `sdk_config.app_framework` with 'flutter', 'react_native', or 'unity'                                                                               |
-| `Embrace.getInstance().addLogRecordExporter(LogRecordExporter)`         | Type changed to `opentelemetry-kotlin` API. Alternative available in `embrace-android-otel-java` module. |
-| `Embrace.getInstance().addSpanExporter(SpanExporter)`                   | Type changed to `opentelemetry-kotlin` API. Alternative available in `embrace-android-otel-java` module. |
-| `Embrace.getInstance().getOpenTelemetry()`                              | `Embrace.getOpenTelemetryKotlin()` or `Embrace.getJavaOpenTelemetry()`                                 |
-| `Embrace.getInstance().setResourceAttribute(AttributeKey, String)`      | `Embrace.setResourceAttribute(String, String)`                                                         |
-| `EmbraceSpan.addLink(SpanContext)`                                      | Type changed to symbol declared in embrace-android-sdk.                                                |
-| `EmbraceSpan.addLink(SpanContext, Map)`                                 | Type changed to symbol declared in embrace-android-sdk.                                                |
-| `EmbraceSpan.getSpanContext()`                                          | Type changed to symbol declared in embrace-android-sdk.                                                |
-| `Embrace.getInstance().trackWebViewPerformance(String, ConsoleMessage)` | Obsolete - no alternative provided.                                                                    |
-| `Embrace.getInstance().trackWebViewPerformance(String, String)`         | Obsolete - no alternative provided.                                                                    |
-| `AppFramework`                                                          | Obsolete - no alternative provided.                                                                    |
-| `StartupActivity`                                                       | Obsolete - no alternative provided.                                                                    |
-| `Embrace.getInstance().registerComposeActivityListener()`               | Obsolete - no alternative provided.                                                                    |
-| `Embrace.getInstance().unregisterComposeActivityListener()`             | Obsolete - no alternative provided.                                                                    |
-| `Embrace.getInstance().logWebView(String)`                              | Obsolete - no alternative provided.                                                                    |
+| Old API                                                                 | New API                                                                                                   |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `Embrace.getInstance().start(Context, AppFramework)`                    | `Embrace.start(Context)` and supply `sdk_config.app_framework` with 'flutter', 'react_native', or 'unity' |
+| `Embrace.getInstance().addLogRecordExporter(LogRecordExporter)`         | Type changed to `opentelemetry-kotlin` API. Alternative available in `embrace-android-otel-java` module.  |
+| `Embrace.getInstance().addSpanExporter(SpanExporter)`                   | Type changed to `opentelemetry-kotlin` API. Alternative available in `embrace-android-otel-java` module.  |
+| `Embrace.getInstance().getOpenTelemetry()`                              | `Embrace.getOpenTelemetryKotlin()` or `Embrace.getJavaOpenTelemetry()`                                    |
+| `Embrace.getInstance().setResourceAttribute(AttributeKey, String)`      | `Embrace.setResourceAttribute(String, String)`                                                            |
+| `EmbraceSpan.addLink(SpanContext)`                                      | Type changed to symbol declared in embrace-android-sdk.                                                   |
+| `EmbraceSpan.addLink(SpanContext, Map)`                                 | Type changed to symbol declared in embrace-android-sdk.                                                   |
+| `EmbraceSpan.getSpanContext()`                                          | Type changed to symbol declared in embrace-android-sdk.                                                   |
+| `Embrace.getInstance().trackWebViewPerformance(String, ConsoleMessage)` | Obsolete - no alternative provided.                                                                       |
+| `Embrace.getInstance().trackWebViewPerformance(String, String)`         | Obsolete - no alternative provided.                                                                       |
+| `AppFramework`                                                          | Obsolete - no alternative provided.                                                                       |
+| `StartupActivity`                                                       | Obsolete - no alternative provided.                                                                       |
+| `Embrace.getInstance().registerComposeActivityListener()`               | Obsolete - no alternative provided.                                                                       |
+| `Embrace.getInstance().unregisterComposeActivityListener()`             | Obsolete - no alternative provided.                                                                       |
+| `Embrace.getInstance().logWebView(String)`                              | Obsolete - no alternative provided.                                                                       |
 
 ##### New Embrace Gradle plugin DSL
 
@@ -210,7 +210,7 @@ The Embrace Gradle Plugin previously had a DSL via the `swazzler` extension. Thi
 extension.
 
 | Old API                                               | New API                                                                 |
-|-------------------------------------------------------|-------------------------------------------------------------------------|
+| ----------------------------------------------------- | ----------------------------------------------------------------------- |
 | `swazzler.disableDependencyInjection`                 | `embrace.autoAddEmbraceDependencies`                                    |
 | `swazzler.disableComposeDependencyInjection`          | `embrace.autoAddEmbraceComposeClickDependency`                          |
 | `swazzler.instrumentOkHttp`                           | `embrace.bytecodeInstrumentation.okhttpEnabled`                         |
@@ -240,7 +240,7 @@ The following functions had overloads manually defined. These have been replaced
 that uses Kotlin's default parameter values. Some parameters that used to be null now require non-null arguments.
 
 | Altered APIs                                  |
-|-----------------------------------------------|
+| --------------------------------------------- |
 | `Embrace.getInstance().logCustomStacktrace()` |
 | `Embrace.getInstance().logException()`        |
 | `Embrace.getInstance().logMessage()`          |
@@ -302,6 +302,7 @@ Below is a list of everything that has changed and how to address it in your cod
 - Replace usage of any deprecated methods (see table below).
 - Remove references to internal symbols that were previously exposed.
 - Use **OkHttp 4.0.0** or later (though 3.13.0+ is supported, it’s not recommended).
+
 :::
 
 ### Moments have been superseded by traces
@@ -353,32 +354,32 @@ swazzler {
 
 Version 6.0.0 of the Embrace Android SDK removed some methods that had been deprecated in 5.x. The renamed methods were removed to reduce confusion and increase consistency across the Embrace SDKs on various platforms, and their replacements behave the same way as the old ones. The methods removed entirely are for functionality that we no longer support. If you were using them for a specific use-case, please speak to us about how you can use the existing APIs instead.
 
-| Old API                                               | New API                                                             | Comments                                                              |
-|-------------------------------------------------------|---------------------------------------------------------------------|:----------------------------------------------------------------------|
-| `Embrace.getInstance().startFragment(String)`         | `Embrace.getInstance().startView(String)`                           | Renamed function to better describe functionality.                    |
-| `Embrace.getInstance().endFragment(String)`           | `Embrace.getInstance().endView(String)`                             | Renamed function to better describe functionality.                    |
-| `Embrace.getInstance().setUserPersona(String)`        | `Embrace.getInstance().addUserPersona(String)`                      | Renamed function to better describe functionality.                    |
-| `Embrace.getInstance().logBreadcrumb(String)`         | `Embrace.getInstance().addBreadcrumb(String)`                       | Renamed function to better describe functionality.                    |
-| `Embrace.getInstance().startEvent()`                  | `Embrace.getInstance().startMoment(String)`                         | Renamed function to better describe functionality.                    |
-| `Embrace.getInstance().endEvent()`                    | `Embrace.getInstance().endMoment(String)`                           | Renamed function to better describe functionality.                    |
-| `Embrace.getInstance().logInfo(String, ...)`          | `Embrace.getInstance().logMessage(...)`                             | Altered function signature to standardise behavior. logInfo(String) without extra parameters is still a valid API.                   |
-| `Embrace.getInstance().logWarning(String, ...)`       | `Embrace.getInstance().logMessage(...)`                             | Altered function signature to standardise behavior. logWarning(String) without extra parameters is still a valid API.                  |
-| `Embrace.getInstance().logError(String, ...)`         | `Embrace.getInstance().logMessage(...)`                             | Altered function signature to standardise behavior. logError(String) without extra parameters is still a valid API.                  |
-| `Embrace.getInstance().logError(Throwable)`           | `Embrace.getInstance().logException()`                              | Altered function signature to standardise behavior.                   |
-| `Embrace.getInstance().logError(StacktraceElement[])` | `Embrace.getInstance().logCustomStacktrace()`                       | Altered function signature to standardise behavior.                   |
-| `EmbraceLogger`                                       | `Embrace.getInstance().logMessage()`                                | Moved function calls to main Embrace interface.                       |
-| `LogType`                                             | `Severity`                                                          | Use Severity enum rather than LogType.                                |
-| `PurchaseFlow`                                        | None                                                                | Please contact Embrace if you have a use-case for this functionality. |
-| `RegistrationFlow`                                    | None                                                                | Please contact Embrace if you have a use-case for this functionality. |
-| `SubscriptionFlow`                                    | None                                                                | Please contact Embrace if you have a use-case for this functionality. |
-| `Embrace.getInstance().logNetworkCall()`              | `Embrace.getInstance().recordNetworkRequest(EmbraceNetworkRequest.fromCompletedRequest(...))` | Renamed function to better describe functionality.                    |
-| `Embrace.getInstance().logNetworkRequest()`              | `Embrace.getInstance().recordNetworkRequest(EmbraceNetworkRequest.fromCompletedRequest(...))` | Renamed function to better describe functionality.                    |
-| `Embrace.getInstance().logNetworkClientError()`       | `Embrace.getInstance().recordNetworkRequest(EmbraceNetworkRequest.fromIncompleteRequest(...))` | Renamed function to better describe functionality.                    |
+| Old API                                               | New API                                                                                        | Comments                                                                                                              |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------- |
+| `Embrace.getInstance().startFragment(String)`         | `Embrace.getInstance().startView(String)`                                                      | Renamed function to better describe functionality.                                                                    |
+| `Embrace.getInstance().endFragment(String)`           | `Embrace.getInstance().endView(String)`                                                        | Renamed function to better describe functionality.                                                                    |
+| `Embrace.getInstance().setUserPersona(String)`        | `Embrace.getInstance().addUserPersona(String)`                                                 | Renamed function to better describe functionality.                                                                    |
+| `Embrace.getInstance().logBreadcrumb(String)`         | `Embrace.getInstance().addBreadcrumb(String)`                                                  | Renamed function to better describe functionality.                                                                    |
+| `Embrace.getInstance().startEvent()`                  | `Embrace.getInstance().startMoment(String)`                                                    | Renamed function to better describe functionality.                                                                    |
+| `Embrace.getInstance().endEvent()`                    | `Embrace.getInstance().endMoment(String)`                                                      | Renamed function to better describe functionality.                                                                    |
+| `Embrace.getInstance().logInfo(String, ...)`          | `Embrace.getInstance().logMessage(...)`                                                        | Altered function signature to standardise behavior. logInfo(String) without extra parameters is still a valid API.    |
+| `Embrace.getInstance().logWarning(String, ...)`       | `Embrace.getInstance().logMessage(...)`                                                        | Altered function signature to standardise behavior. logWarning(String) without extra parameters is still a valid API. |
+| `Embrace.getInstance().logError(String, ...)`         | `Embrace.getInstance().logMessage(...)`                                                        | Altered function signature to standardise behavior. logError(String) without extra parameters is still a valid API.   |
+| `Embrace.getInstance().logError(Throwable)`           | `Embrace.getInstance().logException()`                                                         | Altered function signature to standardise behavior.                                                                   |
+| `Embrace.getInstance().logError(StacktraceElement[])` | `Embrace.getInstance().logCustomStacktrace()`                                                  | Altered function signature to standardise behavior.                                                                   |
+| `EmbraceLogger`                                       | `Embrace.getInstance().logMessage()`                                                           | Moved function calls to main Embrace interface.                                                                       |
+| `LogType`                                             | `Severity`                                                                                     | Use Severity enum rather than LogType.                                                                                |
+| `PurchaseFlow`                                        | None                                                                                           | Please contact Embrace if you have a use-case for this functionality.                                                 |
+| `RegistrationFlow`                                    | None                                                                                           | Please contact Embrace if you have a use-case for this functionality.                                                 |
+| `SubscriptionFlow`                                    | None                                                                                           | Please contact Embrace if you have a use-case for this functionality.                                                 |
+| `Embrace.getInstance().logNetworkCall()`              | `Embrace.getInstance().recordNetworkRequest(EmbraceNetworkRequest.fromCompletedRequest(...))`  | Renamed function to better describe functionality.                                                                    |
+| `Embrace.getInstance().logNetworkRequest()`           | `Embrace.getInstance().recordNetworkRequest(EmbraceNetworkRequest.fromCompletedRequest(...))`  | Renamed function to better describe functionality.                                                                    |
+| `Embrace.getInstance().logNetworkClientError()`       | `Embrace.getInstance().recordNetworkRequest(EmbraceNetworkRequest.fromIncompleteRequest(...))` | Renamed function to better describe functionality.                                                                    |
 
 #### Previously deprecated APIs that have been removed
 
 | Old API                                     | Comments                                                 |
-|---------------------------------------------|----------------------------------------------------------|
+| ------------------------------------------- | -------------------------------------------------------- |
 | `ConnectionQuality`                         | Deprecated API that is no longer supported.              |
 | `ConnectionQualityListener`                 | Deprecated API that is no longer supported.              |
 | `Embrace.enableStartupTracing()`            | Deprecated API that is no longer supported.              |

--- a/docs/android/versioning.md
+++ b/docs/android/versioning.md
@@ -14,11 +14,11 @@ The Embrace Android SDK is built to evolve with the Android ecosystem while main
 For versions **8.0.0 and newer**, the Embrace Android SDK requires the following minimum tool and platform versions:
 
 | **Technology**                  | **Minimum Version** |
-|---------------------------------|---------------------|
+| ------------------------------- | ------------------- |
 | **Kotlin**                      | 2.0.21              |
 | **Gradle**                      | 8.0.2               |
 | **Android Gradle Plugin (AGP)** | 8.0.2               |
-| **minSdk**                      | 26 *                |
+| **minSdk**                      | 26 \*               |
 | **minCompileSdk**               | 34                  |
 | **Build JDK version**           | 17                  |
 | **sourceCompatibility**         | 11                  |

--- a/docs/unity/changelog.md
+++ b/docs/unity/changelog.md
@@ -8,7 +8,7 @@ sidebar_position: 4
 
 ### 2.8.1
 
-*November 25, 2025*
+_November 25, 2025_
 
 Embrace Android SDK Version: [7.5.0](/android/changelog/#750)
 Embrace Apple SDK Version: [6.15.1](/ios/changelog/#6151)
@@ -23,7 +23,7 @@ Embrace Apple SDK Version: [6.15.1](/ios/changelog/#6151)
 Embrace Android SDK Version: [7.5.0](/android/changelog/#750)
 Embrace Apple SDK Version: [6.14.1](/ios/changelog/#6141)
 
-*November 10, 2025*
+_November 10, 2025_
 
 - Trying to start a span that doesn't exist now throws an error
 - Added the ability to ignore URLs for WebView captures
@@ -36,7 +36,7 @@ Embrace Apple SDK Version: [6.14.1](/ios/changelog/#6141)
 Embrace Android SDK Version: [7.5.0](/android/changelog/#750)
 Embrace Apple SDK Version: [6.8.4](/ios/changelog/#684)
 
-*September 4, 2025*
+_September 4, 2025_
 
 - Auto-Instrumentation for:
   - Memory pressure
@@ -49,7 +49,7 @@ Both options are opt-in and low overhead. Please try them!
 Embrace Android SDK Version: [7.5.0](/android/changelog/#750)
 Embrace Apple SDK Version [6.8.4](/ios/changelog/#684)
 
-*August 14, 2025*
+_August 14, 2025_
 
 - Added support for custom symbols path on Android platforms
 - Auto Instrumentation for:
@@ -66,7 +66,7 @@ All are opt-in and low overhead. Please try them out!
 Embrace Android SDK Version: [7.3.0](/android/changelog/#730)
 Embrace Apple SDK Version [6.8.4](/ios/changelog/#684)
 
-*June 16, 2025*
+_June 16, 2025_
 
 - Modified Android SDK interface startup so it is more verbose
 - Modified iOS SDK interface for improved stability and verbosity
@@ -78,7 +78,7 @@ Embrace Apple SDK Version [6.8.4](/ios/changelog/#684)
 
 ### 2.4.0
 
-*April 10, 2025*
+_April 10, 2025_
 
 - Upgraded Embrace Android Dependency to 7.3.0
 - Upgraded Embrace iOS Dependency to 6.8.4
@@ -88,7 +88,7 @@ Embrace Apple SDK Version [6.8.4](/ios/changelog/#684)
 
 ### 2.3.0
 
-*February 11, 2025*
+_February 11, 2025_
 
 - Upgraded Embrace Android dependency to 7.1.0
 - Upgraded Embrace iOS dependency to 6.8.0
@@ -97,14 +97,14 @@ Embrace Apple SDK Version [6.8.4](/ios/changelog/#684)
 
 ### 2.2.0
 
-*January 27, 2025*
+_January 27, 2025_
 
 - Upgraded Embrace iOS dependency to 6.7.1
 - Swapped iOS dependency map method from xcframeworks to SPM
 
 ### 2.1.2
 
-*December 12, 2024*
+_December 12, 2024_
 :::warning Info
 Our Apple SDK and the Unity iOS SDK use Swift, which has a known issue with the current Unity build pipeline. To handle this issue, after creating your Xcode project, add a Dummy Swift file to the UnityFramework target. This will adjust the linker pipeline to invoke Swift appropriately.
 
@@ -124,13 +124,13 @@ You should [remove the Embrace scoped registry](/unity/upgrade-guide/#remove-sco
 
 ### 2.1.1
 
-*November 26, 2024*
+_November 26, 2024_
 
 - Restoration of meta files and patch to local asset path issues
 
 ### 2.1.0
 
-*November 21, 2024*
+_November 21, 2024_
 :::warning Important
 This version of the SDK has been retracted due to local mapping issues with the export.
 :::
@@ -141,13 +141,13 @@ This version of the SDK has been retracted due to local mapping issues with the 
 
 ### 2.0.2
 
-*October 22, 2024*
+_October 22, 2024_
 
 - Patch regarding Unity interaction with disabled Android Native SDK and sampling rate
 
 ### 2.0.1
 
-*October 11th, 2024*
+_October 11th, 2024_
 
 - Android patch of null map argument
 - Upgrade of Embrace iOS SDK to 6.4.2
@@ -156,7 +156,7 @@ This version of the SDK has been retracted due to local mapping issues with the 
 
 ### 2.0.0
 
-*September 30th, 2024*
+_September 30th, 2024_
 :::info Important
 This version of the Unity SDK contains several breaking changes to our API, including the removal of deprecated functions.
 
@@ -170,14 +170,14 @@ Additionally, with the update to Embrace Android 6.13, the SDK now requires Grad
 
 ### 1.26.1
 
-*August 12th, 2024*
+_August 12th, 2024_
 
 - NPE patch for null EmbraceSpanEvents
 - Improvement of AndroidJavaObject memory disposal
 
 ### 1.26.0
 
-*July 18, 2024*
+_July 18, 2024_
 :::warning Important
 This version of the Unity SDK requires desugaring if the required min Android API level is less than 24 and AGP < 7.4.2
 Additionally, for built APKs directly out of Unity, AGP 4.0.1 may be required for desugaring to function correctly.
@@ -195,26 +195,26 @@ For 2022, please see [this](https://docs.unity3d.com/2022.3/Documentation/Manual
 
 ### 1.25.3
 
-*June 24, 2024*
+_June 24, 2024_
 
 - Patch to PBXProject generation on 2021 and later around linker phase construction.
 - Patch to iOS xcframework and framework plugin matrix platform labeling.
 
 ### 1.25.2
 
-*May 23, 2024*
+_May 23, 2024_
 
 - Defensive patch of null case provider issue.
 
 ### 1.25.1
 
-*April 25, 2024*
+_April 25, 2024_
 
 - Patch of issue on newer versions of Unity iOS that involved double injecting into the linker phase.
 
 ### 1.25.0
 
-*April 24, 2024*
+_April 24, 2024_
 :::warning Important
 This version of the Unity SDK requires a later version than 2021.3.16f1. It is tested working on 2021.3.37f1 (the latest LTS version at time of writing). If you receive a "transformer returned null" error of some kind during your build process, please upgrade your LTS engine version.
 :::
@@ -223,7 +223,7 @@ This version of the Unity SDK requires a later version than 2021.3.16f1. It is t
 
 ### 1.24.0
 
-*March 17, 2024*
+_March 17, 2024_
 :::info Important
 This version of Unity has a number of changes to internal namespaces to streamline internal APIs and alignment. We have endeavored to avoid breaking changes. However, if you have subscribed to any existing APIs they may have changed. Please be aware of this when upgrading.
 
@@ -235,7 +235,7 @@ This version also has an issue on newer versions of Unity iOS where the linker p
 
 ### 1.23.0
 
-*February 23, 2024*
+_February 23, 2024_
 
 - Updated to Embrace Android SDK to 6.3.2
   - Improved performance and stability of NDK serialization while the app is under memory pressure
@@ -243,20 +243,20 @@ This version also has an issue on newer versions of Unity iOS where the linker p
 
 ### 1.22.0
 
-*February 5th, 2024*
+_February 5th, 2024_
 
 - Updated changes for Unity Verified Solutions Partnership. Excited to see everyone in the Asset Store!
 
 ### 1.21.0
 
-*January 25th, 2024*
+_January 25th, 2024_
 
 - Updated iOS SDK version to 5.24.5
 - Updated Embrace Unity API signatures for Embrace Android 6.x API
 
 ### 1.20.0
 
-*January 12th, 2024*
+_January 12th, 2024_
 
 - Updated Android SDK to 6.2.0
 - Added screenshot capture for Unity Android Bugshake
@@ -264,13 +264,13 @@ This version also has an issue on newer versions of Unity iOS where the linker p
 
 ### 1.19.1
 
-*December 21st, 2023*
+_December 21st, 2023_
 
 - Patched issue affecting Unity Android EDM customers where a change in dependencies blocked builds.
 
 ### 1.19.0
 
-*December 20th, 2023*
+_December 20th, 2023_
 
 - This version of the SDK had a build blocking issue for customers using EDM. Please update to the latest version.
 - Added support on Unity Android for the Embrace Android Bug Shake feature! Available for users who have Embrace Bug Shake accounts.
@@ -290,7 +290,7 @@ We strongly recommend that Embrace customers ensure their apps meet the criteria
 
 ### 1.18.2
 
-*December 7th 2023*
+_December 7th 2023_
 :::warning Important
 This version of the Unity SDK has two issues:
 
@@ -304,14 +304,14 @@ Please update to the latest version.
 
 ### 1.18.1
 
-*November 6th 2023*
+_November 6th 2023_
 
 - This version of the Unity SDK causes an exception when the Unity SDK tries to capture network requests that are null or that contain null parameters. Please update to the latest version.
 - Hotfix patch for bug for SDK where Android SDK and Unity SDK misalignment resulted in multiple dropped exceptions.
 
 ### 1.18.0
 
-*October 30, 2023*
+_October 30, 2023_
 
 - This version of the Unity SDK introduced a bug between the Unity and internal Android SDK resulting in dropped exceptions when communicating between the two SDKs.
 - Embrace.Instance.SetUserPersona, .LogBreadcrumb, .LogNetworkRequest have been deprecated and replaced by the following functions respectively: .AddUserPersona, .AddBreadcrumb, .RecordNetworkRequest
@@ -326,7 +326,7 @@ Please update to the latest version.
 
 ### 1.17.0
 
-*August 10, 2023*
+_August 10, 2023_
 
 - Added methods for recording iOS and Android push notification data.
 - Updated exceptions API to allow logging of handled exceptions as well as unhandled exceptions.
@@ -336,7 +336,7 @@ Please update to the latest version.
 
 ### 1.16.0
 
-*July 13, 2023*
+_July 13, 2023_
 
 - Fixed an issue that could cause the Unity package manager manifest to be refreshed when a recompile is triggered in the editor
 - Fixed an issue that could lead to unhandled exceptions being lost or misidentified if no valid stack trace was available
@@ -345,7 +345,7 @@ Please update to the latest version.
 
 ### 1.15.0
 
-*June 27, 2023*
+_June 27, 2023_
 
 - Added `GetLastRunEndState` method to retrieve enum indicating a crash or clean exit on the previous app launch
 - Updated Android SDK to version 5.21.0
@@ -353,13 +353,13 @@ Please update to the latest version.
 
 ### 1.14.1
 
-*June 16, 2023*  
+_June 16, 2023_
 
 - Updated iOS SDK to version 5.20.1
 
 ### 1.14.0
 
-*June 14, 2023*
+_June 14, 2023_
 
 - Fixed a potential compatibility issue with other packages using Mono.Cecil
 - Updated Android SDK to version 5.19.0
@@ -367,7 +367,7 @@ Please update to the latest version.
 
 ### 1.13.0
 
-*May 4, 2023*
+_May 4, 2023_
 
 - The Embrace Unity SDK now detects the presence of the External Dependency Manager and automatically configures the Android Swazzler as required
 - Added additional SDK log silencing options to filter logs by type
@@ -380,14 +380,14 @@ Please update to the latest version.
 
 ### 1.12.1
 
-*April 12, 2023*
+_April 12, 2023_
 
 - Fixed configuration selection becoming unresponsive in some states
 - Updated iOS SDK to 5.18.0
 
 ### 1.12.0
 
-*April 11, 2023*
+_April 11, 2023_
 
 - Improved Embrace configuration editor UI
 - Removed editor UI assets from runtime resources
@@ -395,7 +395,7 @@ Please update to the latest version.
 
 ### 1.11.0
 
-*March 24, 2023*
+_March 24, 2023_
 
 - Added support for building for the iOS simulator
 - Added support for tvOS
@@ -405,7 +405,7 @@ Please update to the latest version.
 
 ### 1.10.1
 
-*February 21, 2023*
+_February 21, 2023_
 
 - Fixed automatic network capture beta failing to resolve assemblies in some scenarios when the project contains pre-compiled DLLs.
 - The Embrace Unity SDK now explicitly declares dependencies on the following built-in Unity packages:
@@ -416,7 +416,7 @@ Please update to the latest version.
 
 ### 1.10.0
 
-*February 13, 2023*
+_February 13, 2023_
 
 - Added option to automatically log Unity Scene changes as Views (beta)
 - Updated Android SDK to version 5.13.0
@@ -427,14 +427,14 @@ Please update to the latest version.
 
 ### 1.9.3
 
-*January 23, 2023*
+_January 23, 2023_
 
 - Updated Android SDK to version 5.12.0
 - Updated iOS SDK to version 5.15.0
 
 ### 1.9.2
 
-*January 11, 2023*
+_January 11, 2023_
 
 - Updated Android SDK to version 5.11.0
 - Fixed a bug that could cause the value of `Exception-Free Sessions` shown in the dashboard to be inaccurate for Unity Android apps
@@ -443,13 +443,13 @@ Please update to the latest version.
 
 ### 1.9.1
 
-*December 13, 2022*
+_December 13, 2022_
 
 - Updated Android SDK to version 5.10.0
 
 ### 1.9.0
 
-*December 1, 2022*
+_December 1, 2022_
 
 - The Embrace Unity SDK now automatically updates the version of the `embrace-swazzler` dependency defined in the project's `baseProjectTemplate.gradle`
 - Fixed a bug that could cause multiple small editor windows to open while the Embrace SDK is imported for the first time
@@ -462,14 +462,14 @@ Please update to the latest version.
 
 ### 1.8.1
 
-*November 9, 2022*
+_November 9, 2022_
 
 - Excluded all Embrace assemblies when building for platforms other than iOS and Android.
 - Disabled Embrace IL weaver when building for platforms other than iOS and Android.
 
 ### 1.8.0
 
-*November 3, 2022*
+_November 3, 2022_
 
 - Added support for selecting environment configurations at build time by setting the `EMBRACE_ENVIRONMENTS_NAME` or `EMBRACE_ENVIRONMENTS_INDEX` environment variable
 - Updated Android SDK to version 5.9.0
@@ -480,7 +480,7 @@ Please update to the latest version.
 
 ### 1.7.6
 
-*October 4, 2022*
+_October 4, 2022_
 :::warning Important
 This version of the Unity SDK introduced a bug in the iOS crash handler that can cause the app to freeze when encountering a native crash. Please update to the latest version.
 :::
@@ -491,7 +491,7 @@ This version of the Unity SDK introduced a bug in the iOS crash handler that can
 
 ### 1.7.5
 
-*September 26, 2022*
+_September 26, 2022_
 :::warning Important
 The version of the Embrace Android SDK used in this version contains a bug that can cause Embrace to fail to initialize properly. Please update to Unity SDK version 1.8.0 or later and Android SDK version 5.7.0 or later.
 :::
@@ -500,7 +500,7 @@ The version of the Embrace Android SDK used in this version contains a bug that 
 
 ### 1.7.4
 
-*September 26, 2022*
+_September 26, 2022_
 :::warning Important
 This version includes a compatibility issue with Embrace Android SDK versions 5.6.0 and greater. Please update to Unity SDK version 1.8.0 or later.
 :::
@@ -510,7 +510,7 @@ This version includes a compatibility issue with Embrace Android SDK versions 5.
 
 ### 1.7.3
 
-*September 22, 2022*
+_September 22, 2022_
 :::warning Important
 This version includes a compatibility issue with Embrace Android SDK versions 5.6.0 and greater. Please update to Unity SDK version 1.8.0 or later.
 :::
@@ -521,27 +521,27 @@ This version includes a compatibility issue with Embrace Android SDK versions 5.
 
 ### 1.7.2
 
-*September 15, 2022*
+_September 15, 2022_
 
 - Resolved a dependency conflict between the Embrace SDK and Unity's Burst package.
 - Fixed a UI bug in the Embrace Settings window that occurred when the SDK was reset.
 
 ### 1.7.1
 
-*September 14, 2022*
+_September 14, 2022_
 
 - Removed unnecessary dependency on Unity's default version control package introduced in 1.7.0
 
 ### 1.7.0
 
-*September 12, 2022*
+_September 12, 2022_
 
 - Added support for automatically logging web requests made via UnityWebRequest and HttpClient (BETA)
 - Updated Android SDK to 5.5.4
 
 ### 1.6.0
 
-*August 29, 2022*
+_August 29, 2022_
 
 - Updated iOS SDK to 5.9.1
 - Updated Android SDK Version 5.5.3
@@ -553,39 +553,39 @@ This version includes a compatibility issue with Embrace Android SDK versions 5.
 
 ### 1.5.10
 
-*July 07, 2022*
+_July 07, 2022_
 
 - Fixed breaking change in Embrace class
 - Improved comments
 
 ### 1.5.9
 
-*July 01, 2022*
+_July 01, 2022_
 
 - Upgrades native iOS SDK to 5.9.0
 
 ### 1.5.8
 
-*June 17, 2022*
+_June 17, 2022_
 
 - Upgrades native iOS SDK to 5.8.1
 
 ### 1.5.7
 
-*June 16, 2022*
+_June 16, 2022_
 
 - Added support for symbols upload in Unity 2020.
 - Removed UGUI package from being included in our SDK's unitypackage.
 
 ### 1.5.6
 
-*June 15, 2022*
+_June 15, 2022_
 
 - Fixed compatibility issue with Unity versions prior to 2020.2 introduced in v1.5.5.
 
 ### 1.5.5
 
-*June 10, 2022*
+_June 10, 2022_
 :::warning Important
 This version introduced a compatibility issue with Unity versions before 2020.2. Please upgrade to version 1.5.6.
 :::
@@ -597,66 +597,66 @@ This version introduced a compatibility issue with Unity versions before 2020.2.
 
 ### 1.5.4
 
-*June 06, 2022*
+_June 06, 2022_
 
 - Fixed issue with JSON conversion for log properties.
 - Upgrades native iOS SDK to 5.7.8
 
 ### 1.5.3
 
-*May 27, 2022*
+_May 27, 2022_
 
 - Upgrades native Android SDK to 5.1.0 for builds using the external dependency manager.
 - Upgrades Embrace Swazzler to 5.1.0 to allow NDK stacktrace collection.
 
 ### 1.5.2
 
-*May 16, 2022*
+_May 16, 2022_
 
 - Upgrades native Android SDK to 5.1.0-beta02 for builds using the external dependency manager.
 
 ### 1.5.1
 
-*May 12, 2022*
+_May 12, 2022_
 
 - Upgrades native Android SDK to 5.1.0 for builds using the external dependency manager.
 - Upgrades Embrace Swazzler to 5.1.0 to allow NDK stacktrace collection.
 
 ### 1.5.0
 
-*May 05, 2022*
+_May 05, 2022_
 
 - Added Scoped Registries to allow users to manage, download and install packages using the Package Manager.
 
 ### 1.4.2
 
-*May 04, 2022*
+_May 04, 2022_
 
 - Upgrades native Android SDK to 5.0.4 for builds using the external dependency manager.
 
 ### 1.4.1
 
-*April 22, 2022*
+_April 22, 2022_
 
 - Upgrades native Android SDK to 5.0.2 for builds using the external dependency manager.
 
 ### 1.4.0
 
-*March 15, 2022*
+_March 15, 2022_
 
 - Updated SDK to use the official package management system for Unity. These changes require you to delete your previous version of our SDK before importing the new update.
 - Upgrades native iOS SDK to 5.7.6
 
 ### 1.3.9
 
-*February 28, 2022*
+_February 28, 2022_
 
 - Added demos to help users get started using the Embrace SDK.
 - Fixed serialization bug that affected config environments ability to save.
 
 ### 1.3.8
 
-*February 11, 2022*
+_February 11, 2022_
 
 - Fixes TimeUtil main thread bug.
 - Updated Android config settings.
@@ -664,7 +664,7 @@ This version introduced a compatibility issue with Unity versions before 2020.2.
 
 ### 1.3.7
 
-*January 24, 2022*
+_January 24, 2022_
 
 - Introduces a Settings Window which exposes new features and settings using an editor window.
 - Allows users to create and manage environments which enables you to handle configurations based on your desired environment.
@@ -672,27 +672,27 @@ This version introduced a compatibility issue with Unity versions before 2020.2.
 
 ### 1.3.6
 
-*January 03, 2022*
+_January 03, 2022_
 
 - Updated native SDK's to change default behavior for screenshot capturing.
 
 ### 1.3.5
 
-*December 21, 2021*
+_December 21, 2021_
 
 - Upgrades native iOS SDK to 5.7.1
 - Upgrades native Android SDK to 4.14.0 for builds using the external dependency manager
 
 ### 1.3.4
 
-*December 01, 2021*
+_December 01, 2021_
 
 - Provides validation for the config ID and Token Key, For both the Embrace Post Build Processor and the customer-facing editor
 - Upgrades native Android SDK to 4.13.0 for builds using the external dependency manager.
 
 ### 1.3.3
 
-*November 24, 2021*
+_November 24, 2021_
 
 - Upgrades native iOS SDK to 5.7.0
 - Updated Embrace Android configurations to allow enable_native_monitoring as an option in the Embrace Editor window. Includes a CustomAndroidConfigurations JSON file that allows overriding of the editor configurations.
@@ -700,34 +700,34 @@ This version introduced a compatibility issue with Unity versions before 2020.2.
 
 ### 1.3.2
 
-*October 18, 2021*
+_October 18, 2021_
 
-- Added editor windows to improve the SDK experience.  
-- Enabled users to configure both Android and iOS at the same time using the new Embrace editor window.  
+- Added editor windows to improve the SDK experience.
+- Enabled users to configure both Android and iOS at the same time using the new Embrace editor window.
 - Welcome window informs users of important changes, new features or warns them of potential issues.
 
 ### 1.3.1
 
-*September 17, 2021*
+_September 17, 2021_
 
 - Fixed issue with iOS symbol upload
 
 ### 1.3.0
 
-*September 17, 2021*
+_September 17, 2021_
 
 - Improved how configuration files are handled for both iOS and Android.
 
 ### 1.2.13
 
-*August 9, 2021*
+_August 9, 2021_
 
 - Fixed issue where all dSYM files would not be uploaded for 2019+ Unity projects
 - Enforce execution permission on scripts used in upload of dSYM files when they are copied to the Xcode project
 
 ### 1.2.12
 
-*July 29, 2021*
+_July 29, 2021_
 
 - Made initialization more robust, removing initialization steps from Awake method.
 - Disable SDK gracefully on unsupported platforms.
@@ -735,83 +735,83 @@ This version introduced a compatibility issue with Unity versions before 2020.2.
 
 ### 1.2.11
 
-*July 20, 2021*
+_July 20, 2021_
 
 - Expanded search path in dSYM upload script to automatically include location of dSYMs for all supported Unity versions and configurations.
 
 ### 1.2.10
 
-*July 15, 2021*
+_July 15, 2021_
 
 - Updated to unity-resolver config to use latest version of Android SDK, which addresses a compatibility issue with androidx.lifecycle v.2.3.0+
 - Automatically set dSYM configuration for UnityFramework target.
 
 ### 1.2.9
 
-*July 13, 2021*
+_July 13, 2021_
 
 - Removed references to Unity source in iOS project.
 
 ### 1.2.8
 
-*June 15, 2021*
+_June 15, 2021_
 
 - Include the latest iOS 5.5.2 SDK
 
 ### 1.2.7
 
-*June 14, 2021*
+_June 14, 2021_
 
 - Ensure that the NDK is always referenced correctly
 
 ### 1.2.6
 
-*May 27, 2021*
+_May 27, 2021_
 
 - Update Android dependency to 4.8.10
 - Ensure JNI is always attached to current thread before usage
 
 ### 1.2.5
 
-*May 17, 2021*
+_May 17, 2021_
 
 - Update Android dependency to 4.8.7
 
 ### 1.2.4
 
-*May 17, 2021*
+_May 17, 2021_
 
 - Fix quotes in iOS dSYM build phase to handle path spaces
 - Update run.sh to support iOS dSYM search depth
 
 ### 1.2.3
 
-*May 6, 2021*
+_May 6, 2021_
 
 - Fix iOS timestamps for manually logged network requests
 - Support for latest Android sdk
 
 ### 1.2.2
 
-*May 4, 2021*
+_May 4, 2021_
 
 - Use correct group id in external dependency xml
 
 ### 1.2.1
 
-*May 4, 2021*
+_May 4, 2021_
 
 - Update Android artifact version in external dependency xml
 
 ### 1.2
 
-*April 30, 2021*
+_April 30, 2021_
 
 - Support for unhandled exception reporting
 
 ### 1.1
 
-*March 18, 2021*
+_March 18, 2021_
 
 - Add method to enable debug logging for Android platform
 - Add method to manually log a network request
@@ -819,61 +819,61 @@ This version introduced a compatibility issue with Unity versions before 2020.2.
 
 ### 1.0.14
 
-*March 9, 2021*
+_March 9, 2021_
 
 - Adopt 5.3.7 iOS native build
 - Fix typo in iOS info log severity value
 
 ### 1.0.13
 
-*Feb 22, 2021*
+_Feb 22, 2021_
 
 - Support for the External Dependency Manager
 
 ### 1.0.12
 
-*Feb 8, 2021*
+_Feb 8, 2021_
 
 - Adopt 5.3.6 iOS native build
 
 ### 1.0.11
 
-*Feb 5, 2021*
+_Feb 5, 2021_
 
 - Adopt 5.3.5 iOS native build
 
 ### 1.0.10
 
-*Jan 29, 2021*
+_Jan 29, 2021_
 
 - Adopt 5.3.4 iOS native build
 
 ### 1.0.9
 
-*Jan 26, 2021*
+_Jan 26, 2021_
 
 - Adopt 5.3.3 iOS native build
 
 ### 1.0.8
 
-*Jan 18, 2021*
+_Jan 18, 2021_
 
 - Adopt 5.3.2 iOS native build
 
 ### 1.0.7
 
-*Jan 14, 2021*
+_Jan 14, 2021_
 
 - Updated post-build processing to support pre 2019.3 project configuration on Android
 
 ### 1.0.6
 
-*Jan 11, 2021*
+_Jan 11, 2021_
 
 - Updated post-build processing to support pre 2019.3 project configuration on iOS
 
 ### 1.0.5
 
-*Dec 20, 2020*
+_Dec 20, 2020_
 
 - First public release of the Embrace Unity SDK

--- a/docs/unity/features/build-options.md
+++ b/docs/unity/features/build-options.md
@@ -6,7 +6,7 @@ sidebar_position: 7
 
 ## Build Options
 
-*If you're upgrading from `v1.5.10` or earlier, please note that configuration data will no longer be embedded in our SDK package directory, and instead relocated to your project's Assets folder under `Assets/Embrace`. Any previously defined configurations will be automatically converted at installation time to the updated format described in this document.*
+_If you're upgrading from `v1.5.10` or earlier, please note that configuration data will no longer be embedded in our SDK package directory, and instead relocated to your project's Assets folder under `Assets/Embrace`. Any previously defined configurations will be automatically converted at installation time to the updated format described in this document._
 
 ### SDK Configuration Options
 
@@ -22,13 +22,13 @@ Some applications have complex build pipelines. For example, it's common practic
 
 <img src={require('@site/static/images/unity-configuration-editor.png').default} />
 
-Using this list you can easily add, rename, or remove configurations as needed. Each configuration will create an Android and iOS configuration file stored in the Embrace data directory. The names of these configurations are only used to identify them in the Unity editor, and will not be replicated in the Embrace dashboard.  
+Using this list you can easily add, rename, or remove configurations as needed. Each configuration will create an Android and iOS configuration file stored in the Embrace data directory. The names of these configurations are only used to identify them in the Unity editor, and will not be replicated in the Embrace dashboard.
 
 You can select and edit each configuration by clicking on the toggle to the left of each list item in the **Settings** window, or by selecting a configuration from the **Getting Started** window.
 
 <img src={require('@site/static/images/unity-configuration-select.png').default} />
 
-*NOTE: Most of the time users will not see the creation of configuration data when the **Configurations** list is edited. However, if you happen to peek in the **Configurations** folder, you'll notice that upon defining a configuration objects are created with a GUID-based name. They will get automatically renamed to match user input once the **Update Configurations** button is pressed, or if the **Settings** window loses focus. See the reference images above for an example.*
+_NOTE: Most of the time users will not see the creation of configuration data when the **Configurations** list is edited. However, if you happen to peek in the **Configurations** folder, you'll notice that upon defining a configuration objects are created with a GUID-based name. They will get automatically renamed to match user input once the **Update Configurations** button is pressed, or if the **Settings** window loses focus. See the reference images above for an example._
 
 ### Specifying Configurations At Build Time
 
@@ -47,7 +47,7 @@ Out-of-range indices will result in build failure.
 - Define this variable with the name of an existing configuration (e.g. "Dev", "Staging", or "Prod");
 
 :::warning Important
-  We only support the use of a single environment variable to specify an Embrace configuration. Please be aware that defining both variables at build-time will result in a failed build.
+We only support the use of a single environment variable to specify an Embrace configuration. Please be aware that defining both variables at build-time will result in a failed build.
 :::
 
 For example, let's assume the following configurations are defined ("Dev", "Staging", and "Prod"), and the CI/CD build-time target environment should be "Staging".
@@ -90,7 +90,7 @@ Users will notice that both default and custom configurations already have some 
 
 For example, in the `sdk_config.session` sub-element of the Android configuration, if the `async_end` flag is set to `true` and `max_session_seconds` is set to `120` the output `embrace-config.json` file will only feature those fields as overrides since they are overriding default settings. Likewise, in the iOS configuration the `CRASH_REPORT_ENABLED` and `ENABLE_AUTOMATIC_VIEW_CAPTURE` fields were modified with non-default values, and are therefore the only settings included in the `Embrace-Info.plist` output.
 
-*NOTE: The `app_id` and `api_token` fields are always included.*
+_NOTE: The `app_id` and `api_token` fields are always included._
 
 <img src={require('@site/static/images/unity-config-overrides.png').default} />
 

--- a/docs/unity/features/csharp-symbolication.md
+++ b/docs/unity/features/csharp-symbolication.md
@@ -6,7 +6,7 @@ sidebar_position: 7
 
 ## C# Symbolication
 
-Embrace supports translating Unity il2cpp stack frames from C++ stack traces back to their C# source, including method, assembly name and file name. To enable this feature, the Embrace SDK uploads symbol mapping metadata at build time.  
+Embrace supports translating Unity il2cpp stack frames from C++ stack traces back to their C# source, including method, assembly name and file name. To enable this feature, the Embrace SDK uploads symbol mapping metadata at build time.
 
 This process is completely automatic and requires no additional configuration. However, Embrace does add additional il2cpp compiler arguments to emit the required metadata. If your build process also sets additional arguments, please ensure that the `--emit-source-mapping` and `--emit-method-map` arguments added by Embrace are not removed.
 

--- a/docs/unity/features/exception-logging.md
+++ b/docs/unity/features/exception-logging.md
@@ -9,7 +9,7 @@ sidebar_position: 6
 Embrace automatically logs all unhandled exceptions thrown by your application, including the exception typename, message and managed stack trace when available. All exception logs passed through Unity's logger are captured and considered unhandled, including exceptions logged explicitly via `UnityEngine.Debug.LogException`. It is therefore recommended to send caught/handled exceptions directly to Embrace rather than log them via Unity's logger, as discussed in the [Manual Exception Logging](#manual-exception-logging) section below.
 
 :::warning Important
- Embrace uses Unity's `Application.logMessageReceived` event to capture unhandled exceptions. If the logger is disabled (`Debug.unityLogger.logEnabled = false`), Embrace will not automatically log any exceptions. It is recommended to leave the logger enabled in release builds. If desired, lower severity logs can be disabled using `Debug.unityLogger.filterLogType = LogType.Exception`. [Manual Exception Logs](#manual-exception-logging) is available for use cases where the Unity logger can not be used.
+Embrace uses Unity's `Application.logMessageReceived` event to capture unhandled exceptions. If the logger is disabled (`Debug.unityLogger.logEnabled = false`), Embrace will not automatically log any exceptions. It is recommended to leave the logger enabled in release builds. If desired, lower severity logs can be disabled using `Debug.unityLogger.filterLogType = LogType.Exception`. [Manual Exception Logs](#manual-exception-logging) is available for use cases where the Unity logger can not be used.
 :::
 
 ### Multi-Threaded Exceptions

--- a/docs/unity/features/last-run-end-state.md
+++ b/docs/unity/features/last-run-end-state.md
@@ -8,7 +8,7 @@ sidebar_position: 6
 
 This API enables customers to automatically/programmatically understand if the previous app instance ended in a crash. Depending on your use case, having the ability to query an API to understand if the previous app instance ended in a crash will enable you to adjust the behavior or UI of your app after a crash has occurred.
 
-**What do we mean by previous app instance?**  
+**What do we mean by previous app instance?**
 
 A cold launch, basically. If the app gets backgrounded/resumed so a new session starts, the value returned will not change. So:
 

--- a/docs/unity/features/log-attachments.md
+++ b/docs/unity/features/log-attachments.md
@@ -10,7 +10,7 @@ sidebar_position: 15
 
 A new addition to the Embrace Unity SDK, the Log Attachments API allows binary attachments to be added to log messages. This can be useful if you wish to add arbitrary binary blobs that describe your application's state (such as game state) at a given point in time.
 
-There are two ways to add attachments to the log message:  
+There are two ways to add attachments to the log message:
 
 - by uploading the attachment to Embrace
 - by uploading the attachment to a 3rd party file host and appending the URL for that attachment to your call to the Log Attachments API.

--- a/docs/unity/features/log-network-requests.md
+++ b/docs/unity/features/log-network-requests.md
@@ -35,7 +35,7 @@ var client = new HttpClient(handler);
 
 ### Automatic Network Capture (BETA)
 
-The Embrace Unity SDK includes a compilation post-processor that can weave code to automatically capture all network requests sent through `UnityWebRequest` and `HttpClient`.  
+The Embrace Unity SDK includes a compilation post-processor that can weave code to automatically capture all network requests sent through `UnityWebRequest` and `HttpClient`.
 
 :::warning Important
 Internally, the Embrace weaver uses `Mono.Cecil` to inspect and modify CIL assemblies. The Embrace package resolves this dependency through the Unity Package Manager. If your project already includes `Mono.Cecil` from another source, we recommend switching to the package manager version to avoid conflicts.
@@ -43,7 +43,7 @@ Internally, the Embrace weaver uses `Mono.Cecil` to inspect and modify CIL assem
 
 #### Enabling Automatic Network Capture Weaving
 
-Automatic network capture weaving can be enabled in the **Network Capture** tab of the Embrace settings window (**Tools > Embrace > Settings**).  
+Automatic network capture weaving can be enabled in the **Network Capture** tab of the Embrace settings window (**Tools > Embrace > Settings**).
 
 <img src={require('@site/static/images/unity-network-capture-settings.png').default} />
 

--- a/docs/unity/features/traces.md
+++ b/docs/unity/features/traces.md
@@ -1,5 +1,5 @@
 ---
-title: Traces  
+title: Traces
 description: Record spans to monitor the production performance and success rates of operations within your mobile app.
 sidebar_position: 14
 ---
@@ -15,6 +15,7 @@ Embrace’s Traces solution gives you visibility into any app operation you’d 
 :::info Minimum Requirements
 
 - **We recommend using the latest Embrace Unity SDK version for the most up-to-date API**. Even though Traces is enabled in [Embrace Unity SDK versions 1.26.0 and above](/unity/integration/linking-embrace/).
+
 :::
 
 The Embrace Traces API allows you to:
@@ -60,8 +61,8 @@ To use this feature:
 #### Create a Span
 
 ```csharp
-// Create a span with a given name. 
-// It is important to note that the millisecond time is given 
+// Create a span with a given name.
+// It is important to note that the millisecond time is given
 // in Unix Epoch/POSIX time rather than in .NET ticks.
 Embrace.Instance.StartSpan("SpanName", startTimeMillisPosix);
 ```
@@ -124,6 +125,7 @@ Embrace.Instance.RecordCompletedSpan(
 :::info Minimum Requirements
 
 - In order for a child span to be recorded, you must stop it before stopping the parent span.
+
 :::
 
 ### Support

--- a/docs/unity/integration/configure-embrace-android.md
+++ b/docs/unity/integration/configure-embrace-android.md
@@ -32,7 +32,7 @@ If your version of Unity does not come with supported versions of Gradle and AGP
 
 ### External Dependency Manager - Android Resolver
 
-:::info Notes on minimum versions\*\*
+:::info Notes on minimum versions
 To use the External Dependency Manager you must be using:
 
 - At least version `1.0.13` of the Unity SDK
@@ -140,24 +140,19 @@ Example:
 
 6. In `launcherTemplate.gradle`, add the `embrace-swazzler` plugin.
 
-   ````gradle
+   ```gradle
    apply plugin: 'embrace-swazzler'
-
-   ```text
-
-   ````
+   ```
 
 7. In `gradleTemplate.properties`, add the following if not present:
 
-   ````gradle
+   ```properties
    android.useAndroidX=true
    android.enableJetifier=true
-
-   ```text
+   ```
 
    Finally, if you export your Android build from Unity then you must ensure that the `Create symbols.zip` entry is checked under build settings. Then, you can save the zip file at the root of your project. We will grab the `symbols.zip` file automatically.
 
    <img src={require('@site/static/images/unity-android-build-settings.png').default} />
 
    Now that you've configured the Android platform, it's time to login to the Embrace dashboard.
-   ````

--- a/docs/unity/integration/configure-embrace-android.md
+++ b/docs/unity/integration/configure-embrace-android.md
@@ -32,11 +32,12 @@ If your version of Unity does not come with supported versions of Gradle and AGP
 
 ### External Dependency Manager - Android Resolver
 
-:::info Notes on minimum versions**
+:::info Notes on minimum versions\*\*
 To use the External Dependency Manager you must be using:
 
 - At least version `1.0.13` of the Unity SDK
 - At least version `4.7.0` of the Android Swazzler Plugin
+
 :::
 
 If your project is already using other Android plugins, it is likely you are also using the External Dependency Manager. This is a module that ships with many plugins and handles dependency resolution for you.
@@ -83,7 +84,7 @@ Embrace needs the following templates present in your project:
     }
 ```
 
-   Example:
+Example:
 
 ```groovy
     buildscript {
@@ -107,9 +108,9 @@ Embrace needs the following templates present in your project:
     }
 ```
 
-   Under `settingsTemplate.gradle` file, ensure that the `mavenCentral()` repositories exists.
+Under `settingsTemplate.gradle` file, ensure that the `mavenCentral()` repositories exists.
 
-   Example:
+Example:
 
 ```groovy
     pluginManagement {
@@ -139,14 +140,16 @@ Embrace needs the following templates present in your project:
 
 6. In `launcherTemplate.gradle`, add the `embrace-swazzler` plugin.
 
-   ```gradle
+   ````gradle
    apply plugin: 'embrace-swazzler'
 
    ```text
 
+   ````
+
 7. In `gradleTemplate.properties`, add the following if not present:
 
-   ```gradle
+   ````gradle
    android.useAndroidX=true
    android.enableJetifier=true
 
@@ -157,3 +160,4 @@ Embrace needs the following templates present in your project:
    <img src={require('@site/static/images/unity-android-build-settings.png').default} />
 
    Now that you've configured the Android platform, it's time to login to the Embrace dashboard.
+   ````

--- a/docs/unity/integration/crash-report.md
+++ b/docs/unity/integration/crash-report.md
@@ -37,7 +37,7 @@ UnityEngine.Diagnostics.Utils.ForceCrash(UnityEngine.Diagnostics.ForcedCrashCate
 
 ---
 
-In the next section, you'll be learning how to add Breadcrumb logs to add context to sessions.  
+In the next section, you'll be learning how to add Breadcrumb logs to add context to sessions.
 
 ### iOS Crash Report Settings
 

--- a/docs/unity/integration/log-message-api.md
+++ b/docs/unity/integration/log-message-api.md
@@ -22,9 +22,9 @@ Embrace.Instance.LogMessage("error log", EMBSeverity.Error, new Dictionary<strin
 
 Let's examine the method call above to understand the arguments involved:
 
-- The first argument is a string and represents the message itself.  
+- The first argument is a string and represents the message itself.
 - This is the severity of the event. Typically we use this mechanism for errors, warnings, and occasionally for tracing purposes, but [breadcrumbs](/ios/5x/integration/breadcrumbs) are better for that purpose.
-- The third argument is a dictionary of key-value pairs. When logging an event, break out any details into this dictionary and you will be able to categorize and filter on those values.  
+- The third argument is a dictionary of key-value pairs. When logging an event, break out any details into this dictionary and you will be able to categorize and filter on those values.
 
 import LogLimit from '@site/shared/log-limit.md';
 

--- a/docs/unity/integration/next-steps.md
+++ b/docs/unity/integration/next-steps.md
@@ -16,7 +16,7 @@ please don't hesitate to reach out to us at [support@embrace.io](mailto:support@
 ### Feature Reference
 
 Embrace includes many optional advanced features that can help you figure out some of  
-the most challenging issues.  
+the most challenging issues.
 
 Depending on the platform you are targeting you may want to read one or both of these sections:
 

--- a/docs/unity/integration/unity-cloud-build-compatibility.md
+++ b/docs/unity/integration/unity-cloud-build-compatibility.md
@@ -6,7 +6,7 @@ sidebar_position: 11
 
 ## Working with Unity Cloud Build
 
-Unity provides a service for automating builds of your project called [Unity Cloud Build](https://unity.com/solutions/ci-cd), which can run tests and create executables. This service can be very useful as a part of your CI process; therefore, we work to ensure that the Embrace SDK is compatible with Unity Cloud Build.  
+Unity provides a service for automating builds of your project called [Unity Cloud Build](https://unity.com/solutions/ci-cd), which can run tests and create executables. This service can be very useful as a part of your CI process; therefore, we work to ensure that the Embrace SDK is compatible with Unity Cloud Build.
 
 For Android, the build process should work out of the box. However, for iOS you will need to make a change to how you're working with Unity Cloud Build in order to properly integrate with the service.
 

--- a/docs/unity/upgrade-guide.md
+++ b/docs/unity/upgrade-guide.md
@@ -18,7 +18,8 @@ Unity 6.x already ships with AGP 8.13+ and Java 17, so there is no change requir
 - Remove deprecated properties from Gradle file
 - Remove scoped registry
 - Some features still have yet to be migrated
-  :::
+
+:::
 
 ## iOS SDK Code Initialization
 


### PR DESCRIPTION
## Description of changes

Prettier formatting for the Android and Unity docs (emphasis `*x*`→`_x_`, tables, whitespace, frontmatter). No content changes. Also fixes 7 Docusaurus admonitions whose closing `:::` Prettier had indented into a list, which broke rendering. Verified with `npm run format:check`.

## Checklist before you pull:

- [x] Fits the [Embrace Docs Style Guide](https://embrace.io/docs/embrace-docs-style-guide/).
- [x] No customer-identifying information in text or images.
- [x] No doc file names changed, so no redirects needed.
- [x] No in-page header links changed.