### PR TITLE
Added documentation about environment details

### DIFF
--- a/docs/ios/6x/advanced-features/startup-instrumentation.md
+++ b/docs/ios/6x/advanced-features/startup-instrumentation.md
@@ -56,6 +56,40 @@ The following are **not affected** by late initialization:
 
 The SDK will log an error if it detects that it was started after `didFinishLaunching` or after the app became active.
 
+### Build environment attributes
+
+The startup spans do not carry the build environment on the span itself. Instead, the SDK captures it once at launch as **resource attributes** that are attached to all telemetry in the session — including the `emb-app-startup-cold` and `emb-app-startup-warm` spans. To filter startup spans by how the build was signed and distributed, filter on these attributes rather than on the span name.
+
+Two attributes are captured:
+
+| Attribute key | Shown in the dashboard as | Purpose |
+| --- | --- | --- |
+| `emb.app.environment` | Environment | Coarse production/development bucket |
+| `emb.app.environment_detailed` | Environment Detail | Specific signing/distribution channel |
+
+`Environment` is a coarse two-value bucket:
+
+| Value | Meaning |
+| --- | --- |
+| `prod` | App Store **or** Enterprise (in-house) |
+| `dev` | Everything else, **including TestFlight** |
+
+Because TestFlight builds report `Environment = dev` rather than `prod`, `Environment` alone cannot distinguish most distribution channels. Use `Environment Detail` to identify the exact channel:
+
+| Value | Meaning |
+| --- | --- |
+| `ap` | App Store |
+| `te` | TestFlight |
+| `si` | Simulator |
+| `de` | Development (debug build / run from Xcode) |
+| `ad` | Ad Hoc |
+| `en` | Enterprise (in-house) |
+| `u1`–`u4` | Unknown — the provisioning profile could not be read or parsed |
+
+The SDK determines these values at launch from the app's provisioning profile and App Store receipt: a store build with no embedded provisioning profile is classified as TestFlight (`te`) when the receipt is a `sandboxReceipt`, and App Store (`ap`) otherwise. Builds with an embedded provisioning profile are classified by inspecting the profile's entitlements.
+
+Filter startup spans on `Environment Detail` to scope them to a specific distribution channel. Avoid relying on `Environment` alone, since `prod` folds App Store together with Enterprise, and `dev` folds TestFlight together with simulator, development, and Ad Hoc builds.
+
 ### Manual Instrumentation
 
 You can add your own child spans and attributes to the startup traces through the Embrace client public API.


### PR DESCRIPTION
Summary

Documents the build environment resource attributes (emb.app.environment / emb.app.environment_detailed) on the iOS 6.x Startup Instrumentation page. Adds a "Build environment attributes" section explaining that these are captured once at launch and attached to all telemetry (including emb-app-startup-* spans), with a full value table for Environment Detail (ap, te, si, de, ad, en, u1–u4) and the prod/dev mapping for Environment.

Why

These attribute values were only defined in SDK source (EMBDevice.m) and undocumented, so users had no reference for what the dashboard codes mean or how to filter startup spans by distribution channel.