### PR TITLE
build(deps): remove lychee npm package and require system binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@tabler/icons-react": "^3.44.0",
         "clsx": "2.1.1",
         "docusaurus-pushfeedback": "^1.0.9",
-        "lychee": "^0.2.12",
         "prism-react-renderer": "^2.4.1",
         "pushfeedback-react": "^0.1.76",
         "react": "^19.2.6",
@@ -7358,14 +7357,6 @@
         "astring": "bin/astring"
       }
     },
-    "node_modules/async": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-      "integrity": "sha512-2tEzliJmf5fHNafNwQLJXUasGzQCVctvsNkXmnlELHwypU0p08/rHohYvkqKIjyXpx+0rkrYv6QbhJ+UF4QkBg==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -7703,17 +7694,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffalo": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/buffalo/-/buffalo-0.1.3.tgz",
-      "integrity": "sha512-LCN4KZKQ9tSTg2IMfq5Rrl8g3Vsx3D7X/iBhFjboUvwY0mgnngi/GkU9P7fQzkq0obFcTv4YHwgXyxGmfTIRzQ==",
-      "dependencies": {
-        "tosource": "0.1.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/buffer-from": {
@@ -11094,14 +11074,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/generic-pool": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-1.0.12.tgz",
-      "integrity": "sha512-/FreBY2vliRCKXE+avFbi9pDEQFLPF1jqMM9EMHN7EgqrEUNYw8FOv26JJG3Sfw7THq3Kvk000PxkzjvAl510A==",
-      "engines": {
-        "node": ">= 0.2.0"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -13156,13 +13128,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/juicy": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/juicy/-/juicy-0.2.5.tgz",
-      "integrity": "sha512-mXr84tI+pKwMAnseKmSpPMVZ2KjkViPKo2i5eu5XQAacEXQrv80F1aIEecSZyQW2Ff1dPVsSNGPc1lEkVM/9Yg==",
-      "deprecated": "This package is no longer maintained",
-      "license": "MIT"
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -13405,19 +13370,6 @@
       "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.20.0.tgz",
       "integrity": "sha512-3LVgE7ekWXt04NBci/hjm+NXJxXZeRXuyClL0kA0HONyBOjxhP3ZQkuWIM4Ok3pbeptUW/rj3XcJcJuJVPwPYA==",
       "license": "MPL-1.1"
-    },
-    "node_modules/lychee": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/lychee/-/lychee-0.2.12.tgz",
-      "integrity": "sha512-PdBo9+0mGIF7zSq/eY/h/7EIZIaFZI4AF9sHkz2sMjtTzpBoSc1jmrfgaXlzqqAFe4kwKcBo9CuytvehDOGuQw==",
-      "dependencies": {
-        "async": "0.1.22",
-        "juicy": "0.2.5",
-        "mongolian": "0.1.18",
-        "pg": "0.8.3",
-        "request": "2.9.203",
-        "sanitizer": "0.0.15"
-      }
     },
     "node_modules/mark.js": {
       "version": "8.11.1",
@@ -15837,19 +15789,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/mongolian": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/mongolian/-/mongolian-0.1.18.tgz",
-      "integrity": "sha512-gtEjtn5FfyKBslW0VjHf+hGqKU50NsGhDt4trPYfxlu3OqnWNSFkE0yJrTkwSaP1louLotFoWzKwUfOT9rOQ2w==",
-      "dependencies": {
-        "buffalo": "0.1.3",
-        "taxman": "0.1.1",
-        "waiter": "0.1.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -16633,18 +16572,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pg": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-0.8.3.tgz",
-      "integrity": "sha512-ablcQJGJmIx4y2muZSiyrPo1TyIFVGgz1smR8TyoVsdl1JU/g3+2aOAYJ0YQm+HRXBvHaSbG1y6fpBDSDtVxBA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "generic-pool": "1.0.12"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/picocolors": {
@@ -19200,15 +19127,6 @@
         "entities": "^2.0.0"
       }
     },
-    "node_modules/request": {
-      "version": "2.9.203",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.9.203.tgz",
-      "integrity": "sha512-OWtna9w7yRI/gcfu3VaURgIwE1FHgbz5+fHGQ9GJTHcJ4+uvHnDjXd+N7mVDOv5+1fp1CRPzUSY2wcM345Z2Fw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "engines": [
-        "node >= 0.3.6"
-      ]
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -19473,14 +19391,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/sanitizer": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/sanitizer/-/sanitizer-0.0.15.tgz",
-      "integrity": "sha512-czIh3bPhxzhBUQsbJXMnvPClvh+tQTnY1bkQlHq1nUKyuCjcs/m6zG/gKU3CXet+xhS5vWKWkfZyCmL9/WFFKQ==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/sax": {
       "version": "1.6.0",
@@ -20580,14 +20490,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/taxman": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/taxman/-/taxman-0.1.1.tgz",
-      "integrity": "sha512-woTa2sNzlGapMORbp1PDDeyMl6/2RudPV1z7Wtdx7nzI+FzEawi84yPGzrq57nrkA/kEpWVJZ9K6sXQ9TIhNNg==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/terser": {
       "version": "5.48.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
@@ -20819,14 +20721,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/tosource": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tosource/-/tosource-0.1.1.tgz",
-      "integrity": "sha512-hTnpPZBZP4DggtRpIAxQi74N4z5vs+Yx3Wcj2CNWLAKPRidZbLN2y5bPn1NI5EoojGzQ1btLzaj7poqsiRsmQA==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/totalist": {
@@ -21611,14 +21505,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/waiter": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/waiter/-/waiter-0.1.1.tgz",
-      "integrity": "sha512-OWMX6RloKF1S0uwF/czC08ZFTcksNFRSGeLu3mt7LhQ0daOvnJaKDtgGSULUvuFNfGe093VE9rRGbCo+ceyS+g==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "lychee": "lychee docs/",
+    "lychee": "command -v lychee >/dev/null || { echo 'lychee is not installed. Install it with: brew install lychee' >&2; exit 1; }; lychee docs/",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },
@@ -25,7 +25,6 @@
     "@tabler/icons-react": "^3.44.0",
     "clsx": "2.1.1",
     "docusaurus-pushfeedback": "^1.0.9",
-    "lychee": "^0.2.12",
     "prism-react-renderer": "^2.4.1",
     "pushfeedback-react": "^0.1.76",
     "react": "^19.2.6",


### PR DESCRIPTION
## Summary

- Removes the `lychee` npm package from dependencies. The npm package is an unrelated, unmaintained project (last published over a decade ago) that pulls in deprecated transitive dependencies (`request`, `pg@0.8.3`, `mongolian`, etc.), not the Rust-based link checker the `lychee` script intends to run.
- Updates the `lychee` npm script to use the system-installed lychee binary, with a clear error message (`brew install lychee`) when it is not installed.

## Testing

- `npm run lychee` prints the install instruction and exits 1 when lychee is not installed.
- `npm run lychee` runs the link checker against `docs/` when the binary is present.