### PR TITLE
Changelog update for Unity SDK v2.8.2

### DIFF
--- a/docs/unity/changelog.md
+++ b/docs/unity/changelog.md
@@ -6,6 +6,16 @@ sidebar_position: 4
 
 ## Embrace Unity SDK Changelog
 
+### 2.8.2
+
+_July 6, 2026_
+
+Embrace Android SDK Version: [7.5.0](/android/changelog/#750)
+Embrace Apple SDK Version: [6.15.1](/ios/changelog/#6151)
+
+- Fixed a bug where the Embrace dependencies XML file would fail to be generated when its target directory already existed
+- Added a `NOTICE` file to the package with third-party attributions
+
 ### 2.8.1
 
 _November 25, 2025_

--- a/docs/unity/integration/linking-embrace.md
+++ b/docs/unity/integration/linking-embrace.md
@@ -8,7 +8,7 @@ description: Linking Embrace with your application is quick and easy.
 
 To install Embrace, download our latest SDK below.
 
-[Download Embrace 2.8.1 for Unity](https://github.com/embrace-io/embrace-unity-sdk/releases/download/v2.8.1/EmbraceSDK_2.8.1.unitypackage.zip)
+[Download Embrace 2.8.2 for Unity](https://github.com/embrace-io/embrace-unity-sdk/releases/download/v2.8.2/EmbraceSDK_2.8.2.unitypackage)
 
 Once downloaded, import the Unity Package by selecting Assets -> Import Package
 -> Custom Package.


### PR DESCRIPTION
## Summary
- Add a 2.8.2 changelog entry documenting the `EmbraceEdmUtility` directory-existence fix (dependencies XML file generation) and the new `NOTICE` third-party attributions file bundled with the package
- Update the Unity download link on the linking-embrace page to the 2.8.2 release asset (note the asset is now a plain `.unitypackage`, not a `.zip`)

Native SDK versions are unchanged from 2.8.1 (Android 7.5.0, Apple 6.15.1) — the Apple SDK bump was reverted before this release and will land in a later version.