### PR TITLE
Changelog update for Flutter SDK v4.8.0

### DIFF
--- a/docs/flutter/changelog.md
+++ b/docs/flutter/changelog.md
@@ -11,6 +11,7 @@ sidebar_position: 6
 _Jul 7, 2026_
 
 - Updated Embrace Android SDK to 8.4.0
+- Added `NOTICE` file documenting third-party license attributions
 
 ### 4.7.0
 

--- a/docs/flutter/changelog.md
+++ b/docs/flutter/changelog.md
@@ -6,6 +6,23 @@ sidebar_position: 6
 
 ## Embrace Flutter SDK changelog
 
+### 4.8.0
+
+_Jul 7, 2026_
+
+- Updated Embrace Android SDK to 8.4.0
+
+### 4.7.0
+
+_Jun 9, 2026_
+
+- Added `EmbraceStartupTracker` for automatic time-to-first-frame span instrumentation
+- Added time-to-interactive (TTI) span instrumentation to `EmbraceNavigationObserver`
+- Added `embrace_go_router` package with `EmbraceGoRouterObserver` for automatic navigation tracking and TTI span instrumentation in apps using go_router
+- Updated Embrace Android SDK to 8.3.1
+- Updated Embrace iOS SDK to 6.20.0
+- Fixed null returns from span method channel calls
+
 ### 4.6.0
 
 _Apr 22, 2026_


### PR DESCRIPTION
## Summary
- Add 4.8.0 changelog entry (Updated Embrace Android SDK to 8.4.0), per embrace-io/embrace-flutter-sdk#312
- Backfill missing 4.7.0 entry (EmbraceStartupTracker, TTI instrumentation, `embrace_go_router` package, Android SDK 8.3.1, iOS SDK 6.20.0, span method channel fix)