### PR TITLE
docs: Release notes for React Native SDK v7

### DIFF
--- a/docs/android/integration/index.md
+++ b/docs/android/integration/index.md
@@ -109,7 +109,7 @@ buildscript {
 Then apply the plugin at your module-level `build.gradle`:
 
 ```groovy
-apply plugin: 'embrace-gradle-plugin'
+apply plugin: 'io.embrace.gradle'
 ```
 
 </TabItem>

--- a/docs/react-native/changelog.md
+++ b/docs/react-native/changelog.md
@@ -6,6 +6,17 @@ sidebar_position: 4
 
 ## Embrace React Native SDK Changelog
 
+### 7.0.0
+
+_Jul 13, 2026_
+
+Embrace Android SDK Version: [8.4.0](/android/changelog/#840)  
+Embrace Apple SDK Version [6.19.0](/ios/changelog/#6190)
+
+- This new major version contains breaking changes for Android, before updating please make sure you review the [upgrade guide](/react-native/upgrading/#upgrading-from-6x-to-7x)
+- Updated Android native SDK dependency to [version 8.4.0](/android/changelog/#840)
+- Fixed OpenTelemetry dependency resolution issue in `@embrace-io/react-native-otlp`
+
 ### 6.7.1
 
 _Jul 7, 2026_

--- a/docs/react-native/changelog.md
+++ b/docs/react-native/changelog.md
@@ -90,7 +90,7 @@ _Oct 27, 2025_
 - Updated Android native SDK dependency to [version 7.9.2](/android/changelog/#792)
 
 :::info Important
-This version of the SDK requires Kotlin 2.x when using the `react-native-otlp` package; if you must use Kotlin 1.x you will have to add the following `resolutionStrategy` block to your app's `build.gradle` (groovy):
+This version of the Embrace Android SDK pulls in transitive OpenTelemetry dependencies that cause an okhttp version conflict in React Native. When using `react-native-otlp` with this version, add the following `resolutionStrategy` block to your app's `build.gradle` to pin OpenTelemetry to 1.51.0:
 
 ```groovy
 configurations.all {

--- a/docs/react-native/features/otlp.md
+++ b/docs/react-native/features/otlp.md
@@ -13,6 +13,10 @@ This package provides an easy way to export trace and log data to any OTLP-compa
 
 For more information about how Android / iOS Native custom export work please visit the [OpenTelemetry Integration](/open-telemetry/integration/) guide.
 
+:::info
+Note that exporters must be configured before the native Embrace SDKs are started, so exporters can only be configured in JavaScript using `@embrace-io/react-native-otlp` if you are initializing the SDK in the JavaScript layer of your app. If you are initializing the Embrace Android and iOS SDKs in your native code you will need to [configure custom exporters in the native layer](#initializing-in-the-native-layer)
+:::
+
 ### Install the package
 
 npm:
@@ -115,151 +119,21 @@ function RootLayout() {
 export default RootLayout;
 ```
 
-### Initializing in the native layer
+In case you want to avoid sending telemetry into Embrace you could do it by removing the app_id/token values from each Platform configuration. For more information please see our guide on how to [use Embrace without an account](/react-native/integration/login-embrace-dashboard/#use-without-an-embrace-account).
 
-If you already have the Embrace React Native SDK initialized your native code or if you are planning to run the install scripts mentioned in our [docs section](/react-native/integration/add-embrace-sdk/#native-setup) you could still get the benefit of the OTLP custom export feature. Remember that the install scripts are adding the minimum code needed for initializing Embrace in the Native side but are not integrating the configuration for exporting the telemetry data into your backend of your choice. For this you would need to manually tweak both the Android/iOS sides.
-
-#### iOS
-
-If you already ran the install script mentioned above you would be able to find the `EmbraceInitializer.swift` file with some initial code that you can update:
-
-<Tabs groupId="ios-otlp-native-layer" queryString="ios-otlp-native-layer">
-<TabItem value="swift" label="Swift">
-
-```swift
-import Foundation
-import EmbraceIO
-import RNEmbraceOTLP
-
-let GRAFANA_AUTH_TOKEN = "Basic __YOUR TOKEN__"
-let GRAFANA_TRACES_ENDPOINT = "https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/traces"
-let GRAFANA_LOGS_ENDPOINT = "https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/logs"
-
-@objcMembers class EmbraceInitializer: NSObject {
-    static func start() -> Void {
-        do {
-          // Preparing Span Exporter config with the minimum required
-          let traceExporter = OtlpHttpTraceExporter(endpoint: URL(string: GRAFANA_TRACES_ENDPOINT)!,
-            config: OtlpConfiguration(
-                headers: [("Authorization", GRAFANA_AUTH_TOKEN)]
-            )
-          )
-
-          // Preparing Log Exporter config with the minimum required
-          let logExporter = OtlpHttpLogExporter(endpoint: URL(string: GRAFANA_LOGS_ENDPOINT)!,
-             config: OtlpConfiguration(
-                headers: [("Authorization", GRAFANA_AUTH_TOKEN)]
-             )
-          )
-
-          try Embrace
-              .setup(
-                  options: Embrace.Options(
-                      appId: "__YOUR APP ID__",
-                      platform: .reactNative,
-                      export: OpenTelemetryExport(spanExporter: traceExporter, logExporter: logExporter) // passing the configuration into `export`
-                  )
-              )
-              .start()
-        } catch let e {
-            print("Error starting Embrace \(e.localizedDescription)")
-        }
-    }
-}
-```
-
-</TabItem>
-</Tabs>
-
-#### Android
-
-Similar to iOS, if you already ran the install script you will see the following line already in place in your `MainApplication` file:
-
-```text
-Embrace.getInstance().start(this)
-```
-
-Tweak the `onCreate` method using the following snippet to initialize the exporters with the minimum configuration needed.
+### Disable tracing for the OTLP export network requests
 
 ```mdx-code-block
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 ```
 
-<Tabs groupId="android-otlp-native-layer" queryString="android-otlp-native-layer">
-<TabItem value="kotlin" label="Kotlin">
-
-Add the following imports:
-
-```kotlin
-import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
-import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
-```
-
-And then the following in the OnCreate method:
-
-```kotlin
-// Preparing Span Exporter config with the minimum required
-val spanExporter = OtlpHttpSpanExporter.builder()
-                                .setEndpoint("https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/traces")
-                                .addHeader("Authorization", "Basic __YOUR TOKEN__")
-
-// Preparing Log Exporter config with the minimum required
-val logExporter = OtlpHttpLogRecordExporter.builder()
-                                .setEndpoint("https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/logs")
-                                .addHeader("Authorization", "Basic __YOUR TOKEN__")
-
-Embrace.getInstance().addSpanExporter(spanExporter.build())
-Embrace.getInstance().addLogRecordExporter(logExporter.build())
-
-// This is the line already added by the install script
-Embrace.getInstance().start(this)
-```
-
-</TabItem>
-
-<TabItem value="java" label="Java">
-
-Add the following imports:
-
-```java
-import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
-import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
-```
-
-And then the following in the OnCreate method:
-
-```java
-// Preparing Span Exporter config with the minimum required
-OtlpHttpSpanExporter spanExporter = OtlpHttpSpanExporter.builder()
-                                .setEndpoint("https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/traces")
-                                .addHeader("Authorization", "Basic __YOUR TOKEN__");
-
-// Preparing Log Exporter config with the minimum required
-OtlpHttpLogRecordExporter logExporter = OtlpHttpLogRecordExporter.builder();
-                                .setEndpoint("https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/logs")
-                                .addHeader("Authorization", "Basic __YOUR TOKEN__");
-
-Embrace.getInstance().addSpanExporter(spanExporter.build());
-Embrace.getInstance().addLogRecordExporter(logExporter.build());
-
-// This is the line already added by the install script
-Embrace.getInstance().start(this);
-```
-
-</TabItem>
-</Tabs>
-
-In case you want to avoid sending telemetry into Embrace you could do it by removing the app_id/token values from each Platform configuration. For more information please visit the how to [Use without an Embrace account](/react-native/integration/login-embrace-dashboard#use-without-an-embrace-account) section.
-
-### Disable tracing for the OTLP export network requests
-
 Embrace automatically creates spans for network requests, however because the OTLP export itself makes a network request
 this can produce a cycle where the export's network request creates a span which is then exported and then creates another
 span, etc.
 
 To avoid this you can configure the endpoint to which you are exporting to be ignored on both Android and iOS:
-<Tabs>
+<Tabs groupId="platform" queryString="platform">
 
 <TabItem value="android" label="Android">
 
@@ -287,8 +161,7 @@ page for more details.
 
 <TabItem value="ios" label="iOS">
 
-When initializing in the JS layer you can simply include the `disabledUrlPatterns` key, in the above example if you were
-exporting to Grafana you would add the following in the `SDK_CONFIG`:
+Add the `disabledUrlPatterns` key when initializing in the JS layer. In the above example for exporting to Grafana you would add the following in the `SDK_CONFIG`:
 
 ```json
 "disabledUrlPatterns": [
@@ -296,44 +169,12 @@ exporting to Grafana you would add the following in the `SDK_CONFIG`:
 ]
 ```
 
-When initializing in Swift more configuration is required when setting up Embrace. First add the following import to
-`EmbraceInitializer.swift`:
-
-```swift
-import KSCrash
-```
-
-Then setup a custom `URLSessionCaptureService` that ignores the Grafana export (see [Configuring the iOS SDK](/ios/6x/getting-started/configuration-options.md)
-for more details):
-
-```swift
-let servicesBuilder = CaptureServiceBuilder()
-let urlSessionServiceOptions = URLSessionCaptureService.Options(
-  injectTracingHeader: true,
-  requestsDataSource: nil,
-  ignoredURLs: ["grafana.net"]
-)
-// manually adding the URLSessionCaptureService
-servicesBuilder.add(.urlSession(options: urlSessionServiceOptions))
-// adding defaults
-servicesBuilder.addDefaults()
-```
-
-Finally pass the additional configuration when starting the SDK:
-
-```swift
-try Embrace
-    .setup(
-        options: Embrace.Options(
-          appId: "__YOUR APP ID__",
-          platform: .reactNative,
-          captureServices: servicesBuilder.build(),
-          crashReporter: KSCrashReporter(),
-          export: OpenTelemetryExport(spanExporter: traceExporter, logExporter: logExporter) // passing the configuration into `export`
-        )
-    )
-    .start()
-```
-
 </TabItem>
 </Tabs>
+
+### Initializing in the native layer
+
+If you already have the Embrace React Native SDK initialized in your native code or if you are planning to run the install scripts mentioned in our [integration guide](/react-native/integration/add-embrace-sdk/#native-setup) you can still benefit from the OTLP custom export feature. Remember that the install scripts only add the minimum code required to initialize the native Embrace SDKs. Details on how to configure custom exporters can be found in the native SDK documentation for each platform:
+
+- [Android](/android/features/traces/#export-to-opentelemetry-collectors)
+- [iOS](/ios/6x/advanced-features/opentelemetry-export/)

--- a/docs/react-native/integration/add-embrace-sdk.md
+++ b/docs/react-native/integration/add-embrace-sdk.md
@@ -153,7 +153,7 @@ buildscript {
     google()
   }
   dependencies {
-    classpath "io.embrace:embrace-swazzler:${findProject(':embrace-io_react-native').properties['emb_android_sdk']}"
+    classpath "io.embrace:embrace-gradle-plugin:${findProject(':embrace-io_react-native').properties['emb_android_sdk']}"
   }
 }
 ```
@@ -162,7 +162,7 @@ Then, update the app `build.gradle` file (usually located at `<root>/android/app
 
 ```groovy
 apply plugin: 'com.android.application'
-apply plugin: 'embrace-swazzler'
+apply plugin: 'io.embrace.gradle'
 repositories {
   mavenCentral()
   google()

--- a/docs/react-native/integration/index.md
+++ b/docs/react-native/integration/index.md
@@ -42,10 +42,10 @@ project's native `android/` and `ios/` folders required by the SDK.
 - Android: Android 7.0+ (API 24)
 - `minSdkVersion`: 24+
 - `compileSdkVersion`: 34+
-- Java 11
-- Kotlin 1.8.22+ [\*](/react-native/changelog/#621)
-- Gradle 7.5.1+
-- AGP (Android Gradle Build Tools Plugin) 7.4.2+
+- JDK 17
+- Kotlin 2.0.21+
+- Gradle 8.4+
+- AGP (Android Gradle Build Tools Plugin) 8.3.0+
 
 :::warning
 Fresh React Native projects may need gradle/build tool upgrades. See the aforementioned [app templates](https://github.com/embrace-io/embrace-react-native-sdk/tree/main/integration-tests/templates)

--- a/docs/react-native/integration/session-reporting.md
+++ b/docs/react-native/integration/session-reporting.md
@@ -193,6 +193,30 @@ for more details.
 </TabItem>
 <TabItem value="android" label="Android">
 
+<Tabs groupId="android-language" queryString="android-language">
+
+<TabItem value="kotlin" label="Kotlin">
+Open the `MainApplication.kt` file (usually located at `<project root>/android/app/src/main/java/com/<MyApp>/MainApplication.kt`)
+and add the following to start Embrace:
+
+```kotlin
+import io.embrace.android.embracesdk.Embrace
+
+...
+
+class MainApplication : Application(), ReactApplication {
+  override fun onCreate() {
+    super.onCreate()
+
+    // Add this line right after the super.onCreate()
+    Embrace.start(this)
+  }
+}
+
+```
+</TabItem>
+
+<TabItem value="java" label="Java">
 Open the `MainApplication.java` file (usually located at `<project root>/android/app/src/main/java/com/<MyApp>/MainApplication.java`)
 and add the following to start Embrace:
 
@@ -208,10 +232,12 @@ public class MainApplication extends Application implements ReactApplication {
         super.onCreate();
 
         // Add this line right after the super.onCreate();
-        Embrace.getInstance().start(this);
+        Embrace.INSTANCE.start(this);
     }
 }
 ```
+</TabItem>
+</Tabs>
 
 </TabItem>
 </Tabs>

--- a/docs/react-native/upgrading.md
+++ b/docs/react-native/upgrading.md
@@ -40,9 +40,23 @@ The minimum supported Android runtime for React Native is unchanged (Android 7.0
 
 #### Rename the Embrace Gradle plugin
 
-The plugin's artifact and ID have been renamed. Update the two places it appears in your Android project.
+The `embrace-swazzler` plugin artifact and plugin ID have been renamed. Update the references in your root `android/build.gradle` and `android/app/build.gradle` files:
 
-In your root `android/build.gradle`, update the `buildscript` classpath:
+##### Expo Config Plugin
+
+If you are using our Expo config plugin you can simply re-run `npx expo prebuild` - the config plugin will apply the rename.
+
+##### Setup script
+
+Non-Expo users can re-run the setup script that ships with the SDK to apply the plugin rename:
+
+```shell-session
+node node_modules/@embrace-io/react-native/lib/scripts/setup/installAndroid.js
+```
+
+##### Manual setup
+
+Alternatively, you can update your Gradle files manually. In your root `android/build.gradle`, update the `buildscript` classpath:
 
 ```groovy
 // Before
@@ -59,8 +73,6 @@ apply plugin: 'embrace-swazzler'
 // After
 apply plugin: 'io.embrace.gradle'
 ```
-
-If you originally set Embrace up with our Android setup script, you can re-run it to apply the plugin rename: `node node_modules/@embrace-io/react-native/lib/scripts/setup/installAndroid.js`.
 
 #### Remove the OpenTelemetry pin for `@embrace-io/react-native-otlp`
 

--- a/docs/react-native/upgrading.md
+++ b/docs/react-native/upgrading.md
@@ -27,16 +27,18 @@ Upgrade to the latest `7.x` versions of the Embrace React Native packages, eithe
 
 #### Meet the new Android minimum versions
 
-Embrace Android SDK 8.x raises the minimum supported build tooling. Because React Native projects use a `minSdkVersion` below 26 (the default is 24), the following minimums apply:
+Embrace Android SDK 8.x raises the [Minimum supported versions](/android/upgrading/#minimum-supported-versions) for Android build tooling. If you are using React Native 0.76 or lower, you may need to update your native Android configuration files. We recommend the following versions:
 
-| Technology       | Minimum version |
-| ---------------- | --------------- |
-| JDK (build-time) | 17              |
-| Kotlin           | 2.0.21          |
-| Gradle           | 8.4             |
-| AGP              | 8.3.0           |
+- JDK 17
+- Kotlin 2.0.21+
+- Gradle 8.7+ \*
+- AGP 8.6.0+ \*
 
-The minimum supported Android runtime for React Native is unchanged (Android 7.0 / `minSdk` 24). Please see [Minimum supported versions](/android/upgrading/#minimum-supported-versions) in the Android guide for full details.
+\* For minSdk < 26 the minimum requirement is Gradle 8.4 and AGP 8.3.0, however we recommend using AGP 8.6.0+ / Gradle 8.7+ to avoid Kotlin metadata warnings emitted by the lint analyzer on older AGP versions.
+
+:::info
+Our [React Native app templates](https://github.com/embrace-io/embrace-react-native-sdk/tree/main/integration-tests/templates) contain a tested configuration for each supported React Native version that you may find useful as a guide for configuring your project.
+:::
 
 #### Rename the Embrace Gradle plugin
 

--- a/docs/react-native/upgrading.md
+++ b/docs/react-native/upgrading.md
@@ -133,12 +133,11 @@ That’s it! Your application should now build successfully.
 
 :::info Summary
 
-- Kotlin 2.x or higher is required when using `react-native-otlp`.
+- Pin OpenTelemetry dependencies to 1.51.0 in your app's Gradle when using `@embrace-io/react-native-otlp`.
 
 :::
 
-This version of the SDK requires Kotlin 2.x when using the `react-native-otlp` package.
-If you must use Kotlin 1.x you will have to add the following `resolutionStrategy` block to your app's `build.gradle` (groovy):
+This version of the Embrace Android SDK pulls in transitive OpenTelemetry dependencies that cause an okhttp version conflict in React Native. When using `react-native-otlp` with this version, add the following `resolutionStrategy` block to your app's `build.gradle` to pin OpenTelemetry to 1.51.0:
 
 ```groovy
 configurations.all {

--- a/docs/react-native/upgrading.md
+++ b/docs/react-native/upgrading.md
@@ -6,6 +6,66 @@ description: Upgrade guide for Embrace React Native SDK versions
 
 ## Upgrade guide
 
+### Upgrading from 6.x to 7.x
+
+:::info Summary
+
+- The Embrace Android SDK has been updated from 7.x (v7.9.2) to 8.x (v8.4.0):
+  - New minimum version requirements for the JDK, Kotlin, Gradle, and AGP (see below).
+  - The `embrace-swazzler` Gradle plugin has been renamed to `embrace-gradle-plugin`.
+- No JavaScript API changes
+
+:::
+
+The breaking changes in this release are Android-only. There are no JavaScript API changes.
+
+The steps below outline the project configuration changes required for all React Native projects, however if you call the Embrace Android SDK directly from native code or use a custom `swazzler {}` Gradle DSL block, please review the [Android Upgrade guide (7.x → 8.x)](/android/upgrading/#upgrading-from-7x-to-8x) for full details of all breaking changes.
+
+#### Update the Embrace packages
+
+Upgrade to the latest `7.x` versions of the Embrace React Native packages, either by bumping the versions in your `package.json` and running `npm install` / `yarn install`, or by removing the existing `@embrace-io/*` packages and reinstalling them.
+
+#### Meet the new Android minimum versions
+
+Embrace Android SDK 8.x raises the minimum supported build tooling. Because React Native projects use a `minSdkVersion` below 26 (the default is 24), the following minimums apply:
+
+| Technology       | Minimum version |
+| ---------------- | --------------- |
+| JDK (build-time) | 17              |
+| Kotlin           | 2.0.21          |
+| Gradle           | 8.4             |
+| AGP              | 8.3.0           |
+
+The minimum supported Android runtime for React Native is unchanged (Android 7.0 / `minSdk` 24). Please see [Minimum supported versions](/android/upgrading/#minimum-supported-versions) in the Android guide for full details.
+
+#### Rename the Embrace Gradle plugin
+
+The plugin's artifact and ID have been renamed. Update the two places it appears in your Android project.
+
+In your root `android/build.gradle`, update the `buildscript` classpath:
+
+```groovy
+// Before
+classpath "io.embrace:embrace-swazzler:${findProject(':embrace-io_react-native').properties['emb_android_sdk']}"
+// After
+classpath "io.embrace:embrace-gradle-plugin:${findProject(':embrace-io_react-native').properties['emb_android_sdk']}"
+```
+
+In your `android/app/build.gradle`, update the applied plugin ID:
+
+```groovy
+// Before
+apply plugin: 'embrace-swazzler'
+// After
+apply plugin: 'io.embrace.gradle'
+```
+
+If you originally set Embrace up with our Android setup script, you can re-run it to apply the plugin rename: `node node_modules/@embrace-io/react-native/lib/scripts/setup/installAndroid.js`.
+
+#### Remove the OpenTelemetry pin for `@embrace-io/react-native-otlp`
+
+If you use the `react-native-otlp` package and previously added the OpenTelemetry `resolutionStrategy` block to your app's `build.gradle` outlined [here](#upgrading-to-621) you can now safely remove it. The underlying dependency conflict has been fixed upstream in the `react-native-otlp` package, so pinning the `io.opentelemetry:*` artifacts to `1.51.0` is no longer required.
+
 ### Upgrading to 6.3.0
 
 :::info Summary


### PR DESCRIPTION
Docs updates for React Native v7 release:

- Added an upgrade guide and changelog entry
- Updated the integration instructions and minimum version requirements in the integration guide
- Updated the wording for the OTLP issue in the 6.2.1 changelog and upgrade guide - previously this stated that the workaround was only required when using Kotlin 1.x, which was incorrect.
- Fixed a typo in the Android SDK gradle integration instructions.

